### PR TITLE
Make utility class in edit-config protected

### DIFF
--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
@@ -253,7 +253,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
         return Lists.reverse(qNames);
     }
 
-    private static YangInstanceIdentifier retrieveElementYII(
+    protected static YangInstanceIdentifier retrieveElementYII(
         final SchemaContext schemaContext, final NormalizedNode<?, ?> normalizedNode,
             final Element deviceElement, final String xpathExpression) {
         final List<Node> nodes = RPCUtil.getNodes(deviceElement.getChildNodes());


### PR DESCRIPTION
This utility method is very helpful for classes derived from EditConfigRequestProcessor