### PR TITLE
replace .get() by .get(<timeout>) (12.2.x)

### DIFF
--- a/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
+++ b/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -91,7 +92,9 @@ public class ActionDeviceTest {
             ExecutionException, TimeoutException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
 
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage schemaResponse = sentRequesttoDevice(
                     sessionListener, "get_schemas_request.xml");
 
@@ -118,7 +121,9 @@ public class ActionDeviceTest {
     public void actionsTest() throws IOException, URISyntaxException, SAXException, InterruptedException,
             ExecutionException, TimeoutException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage startActionResponse = sentRequesttoDevice(sessionListener, START_ACTION_REQUEST_XML);
             final String startResultTag = startActionResponse.getDocument().getDocumentElement().getElementsByTagName(
                     START_TAG).item(0).getTextContent();

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
@@ -19,6 +19,7 @@ import java.io.Reader;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import javax.xml.transform.TransformerException;
 import org.opendaylight.yangtools.yang.binding.DataContainer;
 import org.opendaylight.yangtools.yang.binding.DataObject;
@@ -70,11 +71,12 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
                 responseData = new ResponseData(Collections.singletonList(containerNode));
             }
             return CompletableFuture.completedFuture(responseData);
-        } catch (final ExecutionException | InterruptedException | SerializationException | TransformerException e) {
+        } catch (final ExecutionException | InterruptedException | SerializationException | TransformerException | TimeoutException e) {
             LOG.error("Error while executing RPC", e);
             return CompletableFuture.failedFuture(e);
         }
     }
 
-    protected abstract RpcResult<O> execMethod(T input) throws ExecutionException, InterruptedException;
+    protected abstract RpcResult<O> execMethod(T input)
+            throws ExecutionException, InterruptedException, TimeoutException;
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
@@ -71,7 +71,8 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
                 responseData = new ResponseData(Collections.singletonList(containerNode));
             }
             return CompletableFuture.completedFuture(responseData);
-        } catch (final ExecutionException | InterruptedException | SerializationException | TransformerException | TimeoutException e) {
+        } catch (final ExecutionException | InterruptedException | SerializationException | TransformerException
+                | TimeoutException e) {
             LOG.error("Error while executing RPC", e);
             return CompletableFuture.failedFuture(e);
         }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAddNodeToTopologyProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAddNodeToTopologyProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.AddNodeIntoTopologyInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.AddNodeIntoTopologyOutput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
@@ -39,9 +42,9 @@ public class NetworkTopologyServiceAddNodeToTopologyProcessor extends
 
     @Override
     protected RpcResult<AddNodeIntoTopologyOutput> execMethod(final AddNodeIntoTopologyInput input)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<AddNodeIntoTopologyOutput> voidRpcResult = this.networkTopologyRpcsService.addNodeIntoTopology(
-                input).get();
+                input).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceCreateTopologyProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceCreateTopologyProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.CreateTopologyInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.CreateTopologyOutput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
@@ -37,9 +40,9 @@ public class NetworkTopologyServiceCreateTopologyProcessor extends
 
     @Override
     protected RpcResult<CreateTopologyOutput> execMethod(final CreateTopologyInput input)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<CreateTopologyOutput> voidRpcResult = this.networkTopologyRpcsService.createTopology(input)
-                .get();
+                .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetNodeFromTopologyProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetNodeFromTopologyProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetNodeFromTopologyByIdInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetNodeFromTopologyByIdOutput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
@@ -38,9 +41,9 @@ public class NetworkTopologyServiceGetNodeFromTopologyProcessor extends
 
     @Override
     protected RpcResult<GetNodeFromTopologyByIdOutput> execMethod(final GetNodeFromTopologyByIdInput input)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<GetNodeFromTopologyByIdOutput> voidRpcResult = networkTopologyRpcsService
-                .getNodeFromTopologyById(input).get();
+                .getNodeFromTopologyById(input).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetTopologiesProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetTopologiesProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetTopologiesInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetTopologiesOutput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
@@ -37,8 +40,9 @@ public class NetworkTopologyServiceGetTopologiesProcessor extends NetworkTopolog
 
     @Override
     protected RpcResult<GetTopologiesOutput> execMethod(final GetTopologiesInput input) throws ExecutionException,
-            InterruptedException {
-        final RpcResult<GetTopologiesOutput> voidRpcResult = this.networkTopologyRpcsService.getTopologies(input).get();
+            InterruptedException, TimeoutException {
+        final RpcResult<GetTopologiesOutput> voidRpcResult = this.networkTopologyRpcsService.getTopologies(input)
+                .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetTopologyByIdProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetTopologyByIdProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetTopologyByIdInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetTopologyByIdOutput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
@@ -37,9 +40,9 @@ public class NetworkTopologyServiceGetTopologyByIdProcessor extends
 
     @Override
     protected RpcResult<GetTopologyByIdOutput> execMethod(final GetTopologyByIdInput input)
-        throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<GetTopologyByIdOutput> voidRpcResult = networkTopologyRpcsService
-                .getTopologyById(input).get();
+                .getTopologyById(input).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetTopologyIdsProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceGetTopologyIdsProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetTopologyIdsInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.GetTopologyIdsOutput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
@@ -37,9 +40,9 @@ public class NetworkTopologyServiceGetTopologyIdsProcessor extends NetworkTopolo
 
     @Override
     protected RpcResult<GetTopologyIdsOutput> execMethod(final GetTopologyIdsInput input) throws ExecutionException,
-            InterruptedException {
+            InterruptedException, TimeoutException {
         final RpcResult<GetTopologyIdsOutput> voidRpcResult = this.networkTopologyRpcsService.getTopologyIds(input)
-                .get();
+                .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceRemoveAllTopologiesProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceRemoveAllTopologiesProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.RemoveAllTopologiesInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.RemoveAllTopologiesOutput;
@@ -38,9 +41,9 @@ public class NetworkTopologyServiceRemoveAllTopologiesProcessor extends NetworkT
 
     @Override
     protected RpcResult<RemoveAllTopologiesOutput> execMethod(final RemoveAllTopologiesInput input)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<RemoveAllTopologiesOutput> voidRpcResult = this.networkTopologyRpcsService.removeAllTopologies(
-                input).get();
+                input).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceRemoveNodeProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceRemoveNodeProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.RemoveNodeFromTopologyInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.RemoveNodeFromTopologyOutput;
@@ -37,9 +40,9 @@ public class NetworkTopologyServiceRemoveNodeProcessor extends
 
     @Override
     protected RpcResult<RemoveNodeFromTopologyOutput> execMethod(final RemoveNodeFromTopologyInput input)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<RemoveNodeFromTopologyOutput> voidRpcResult = this.networkTopologyRpcsService
-                .removeNodeFromTopology(input).get();
+                .removeNodeFromTopology(input).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceRemoveTopologyProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceRemoveTopologyProcessor.java
@@ -7,7 +7,10 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.NetworkTopologyRpcsService;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.RemoveTopologyInput;
 import org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs.rev180320.RemoveTopologyOutput;
@@ -37,9 +40,9 @@ public class NetworkTopologyServiceRemoveTopologyProcessor extends
 
     @Override
     protected RpcResult<RemoveTopologyOutput> execMethod(final RemoveTopologyInput input)
-            throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final RpcResult<RemoveTopologyOutput> voidRpcResult = this.networkTopologyRpcsService.removeTopology(input)
-                .get();
+                .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         return voidRpcResult;
     }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/rpcs/NetworkTopologyServiceImpl.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/rpcs/NetworkTopologyServiceImpl.java
@@ -403,7 +403,8 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
                         .child(org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology
                             .rev131021.network.topology.topology.Node.class, nk)
                         .build();
-                final Optional<org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node> nodeOptional =
+                final Optional<org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology
+                        .rev131021.network.topology.topology.Node> nodeOptional =
                         readTx.read(datastoreType, tii).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 if (nodeOptional.isPresent()) {
                     final org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/rpcs/NetworkTopologyServiceImpl.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/rpcs/NetworkTopologyServiceImpl.java
@@ -11,6 +11,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -19,6 +20,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.ReadTransaction;
 import org.opendaylight.mdsal.binding.api.WriteTransaction;
@@ -173,7 +176,7 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
                         .setNode(finalListOper)
                         .build();
                 writeTx.merge(LogicalDatastoreType.OPERATIONAL, tii, topology);
-                writeTx.commit().get();
+                writeTx.commit().get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
                 final AddNodeIntoTopologyOutput addNodeIntoTopologyOutput = new AddNodeIntoTopologyOutputBuilder()
                         .build();
@@ -203,7 +206,7 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
                                 topology.key()).build();
                 writeTx.merge(LogicalDatastoreType.CONFIGURATION, tii, topology);
                 writeTx.merge(LogicalDatastoreType.OPERATIONAL, tii, topology);
-                writeTx.commit().get();
+                writeTx.commit().get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 final CreateTopologyOutput topologyOutput = new CreateTopologyOutputBuilder().build();
 
                 final RpcResult<CreateTopologyOutput> rpcResult = RpcResultBuilder.success(topologyOutput).build();
@@ -315,8 +318,8 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
                         InstanceIdentifier.builder(NetworkTopology.class)
                         .child(Topology.class, topology.key())
                         .build();
-                final Optional<Topology> readTopology =
-                    readTx.read(LogicalDatastoreType.CONFIGURATION, tii).get();
+                final Optional<Topology> readTopology = readTx.read(LogicalDatastoreType.CONFIGURATION, tii)
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 final List<org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs
                     .rev180320.topology.data.Topology> finalTopology =
                         new ArrayList<>();
@@ -400,9 +403,8 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
                         .child(org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology
                             .rev131021.network.topology.topology.Node.class, nk)
                         .build();
-                final Optional<org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology
-                    .rev131021.network.topology.topology.Node> nodeOptional =
-                        readTx.read(datastoreType, tii).get();
+                final Optional<org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node> nodeOptional =
+                        readTx.read(datastoreType, tii).get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 if (nodeOptional.isPresent()) {
                     final org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology
                         .rev131021.network.topology.topology.Node node = nodeOptional.get();
@@ -460,8 +462,8 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
                     NetworkTopologyServiceImpl.this.dataBrokerService.newReadOnlyTransaction();
                 final InstanceIdentifier<NetworkTopology> tii =
                         InstanceIdentifier.builder(NetworkTopology.class).build();
-                final Optional<NetworkTopology> networkTopology =
-                    readTx.read(LogicalDatastoreType.CONFIGURATION, tii).get();
+                final Optional<NetworkTopology> networkTopology = readTx.read(LogicalDatastoreType.CONFIGURATION, tii)
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 if (networkTopology.isPresent()) {
                     final org.opendaylight.yang.gen.v1.urn.tech.pantheon.netconfdevice.network.topology.rpcs
                         .rev180320.topology.data.TopologyBuilder topologyBuilder =
@@ -530,20 +532,21 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
 
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private void removeFromDatastore(final InstanceIdentifier<?> instanceIdentifier)
-        throws ExecutionException, InterruptedException {
+            throws ExecutionException, InterruptedException, TimeoutException {
         final WriteTransaction writeTx = this.dataBrokerService.newWriteOnlyTransaction();
         writeTx.delete(LogicalDatastoreType.CONFIGURATION, instanceIdentifier);
         writeTx.delete(LogicalDatastoreType.OPERATIONAL, instanceIdentifier);
-        writeTx.commit().get();
+        writeTx.commit().get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
-    private List<TopologyId> prepareGetTopologyIds() throws ExecutionException, InterruptedException {
+    private List<TopologyId> prepareGetTopologyIds() throws ExecutionException, InterruptedException, TimeoutException {
         final ReadTransaction readTx = this.dataBrokerService.newReadOnlyTransaction();
         final InstanceIdentifier<NetworkTopology> ntii =
                 InstanceIdentifier.builder(NetworkTopology.class)
                 .build();
-        final Optional<NetworkTopology> networkTopology = readTx.read(LogicalDatastoreType.CONFIGURATION, ntii).get();
+        final Optional<NetworkTopology> networkTopology = readTx.read(LogicalDatastoreType.CONFIGURATION, ntii)
+                .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         final List<TopologyId> topologyIds = new ArrayList<>();
         if (networkTopology.isPresent()) {
             for (final Topology topology : networkTopology.get().nonnullTopology()) {

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -13,6 +13,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
 
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -97,7 +98,9 @@ public class DeviceTest {
             ExecutionException, TimeoutException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
 
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage schemaResponse = sendRequestToDevice(GET_SCHEMAS_REQUEST_XML, sessionListener);
 
             final NodeList schema = schemaResponse.getDocument().getDocumentElement().getElementsByTagName("schema");
@@ -124,7 +127,9 @@ public class DeviceTest {
     public void deviceConfigOperationsTest() throws InterruptedException, ExecutionException,
             IOException, TimeoutException, URISyntaxException, SAXException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage createTopoResponse =
                     sendRequestToDevice(CREATE_TOPOLOGY_CONFIG_REQUEST_XML, sessionListener);
             assertTrue(containsOkElement(createTopoResponse));
@@ -166,7 +171,9 @@ public class DeviceTest {
     public void deviceRpcTest() throws ExecutionException, InterruptedException, IOException, URISyntaxException,
             SAXException, TimeoutException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
 
             final NetconfMessage createTopoResponse =
                     sendRequestToDevice(CREATE_TOPOLOGY_RPC_REQUEST_XML, sessionListener);

--- a/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
+++ b/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertTrue;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 import io.lighty.netconf.device.notification.Main;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -96,7 +97,9 @@ public class NotificationTest {
             ExecutionException, TimeoutException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
 
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage schemaResponse = sendRequesttoDevice(sessionListener, GET_SCHEMAS_REQUEST_XML);
 
             final NodeList schema = schemaResponse.getDocument().getDocumentElement().getElementsByTagName("schema");
@@ -126,7 +129,9 @@ public class NotificationTest {
         final NotificationNetconfSessionListener sessionListener =
                 new NotificationNetconfSessionListener(countDownLatch, EXPECTED_NOTIFICATION_PAYLOAD);
 
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage subscribeResponse =
                     sendRequesttoDevice(sessionListener, SUBCRIBE_TO_NOTIFICATIONS_REQUEST_XML);
 

--- a/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
+++ b/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
@@ -67,7 +67,8 @@ public abstract class ToasterServiceAbstractProcessor<I extends DataObject, O ex
 
             //5. create response
             return CompletableFuture.completedFuture(new ResponseData(Collections.singletonList(data)));
-        } catch (final InterruptedException | ExecutionException | SerializationException | TransformerException | TimeoutException e) {
+        } catch (final InterruptedException | ExecutionException | SerializationException | TransformerException
+                | TimeoutException e) {
             LOG.error("Error while executing RPC", e);
             return CompletableFuture.failedFuture(e);
         }

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.codecs.xml.XmlUtil;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -93,7 +94,9 @@ public class ToasterDeviceTest {
             ExecutionException, TimeoutException {
         final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
 
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage schemaResponse = sentRequestToDevice(GET_SCHEMAS_REQUEST_XML,
                     sessionListener);
 
@@ -123,7 +126,9 @@ public class ToasterDeviceTest {
         final CountDownLatch notificationReceivedLatch = new CountDownLatch(1);
         final SimpleNetconfClientSessionListener sessionListener =
                 new NotificationNetconfSessionListener(notificationReceivedLatch);
-        try (NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener)).get()) {
+        try (NetconfClientSession session =
+                dispatcher.createClient(createSHHConfig(sessionListener))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
             final NetconfMessage subscribeResponse =
                     sentRequestToDevice(SUBSCRIBE_TO_NOTIFICATIONS_REQUEST_XML, sessionListener);
             assertTrue(containsOkElement(subscribeResponse));

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
@@ -12,6 +12,7 @@ import io.lighty.codecs.api.SerializationException;
 import io.lighty.netconf.device.requests.RequestProcessor;
 import io.lighty.netconf.device.requests.RpcHandlerImpl;
 import io.lighty.netconf.device.requests.notification.NotificationPublishServiceImpl;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -109,10 +110,10 @@ public class NetconfDeviceImpl implements NetconfDevice {
                     .deserialize(netconfDeviceServices.getRootSchemaNode(), reader);
             DOMDataTreeWriteTransaction writeTx = netconfDeviceServices.getDOMDataBroker().newWriteOnlyTransaction();
             writeTx.put(datastoreType, YangInstanceIdentifier.empty(), initialDataBI);
-            writeTx.commit().get();
+            writeTx.commit().get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             final String dataTreeString = NormalizedNodes.toStringTree(initialDataBI);
             LOG.trace("Initial {} datastore data: {}", datastoreType, dataTreeString);
-        } catch (SerializationException | IOException | ExecutionException | InterruptedException e) {
+        } catch (SerializationException | IOException | ExecutionException | InterruptedException | TimeoutException e) {
             String msg = "Unable to set initial state of " + datastoreType + " datastore from XML!";
             LOG.error(msg, e);
             throw new IllegalStateException(msg, e);

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
@@ -113,7 +113,8 @@ public class NetconfDeviceImpl implements NetconfDevice {
             writeTx.commit().get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             final String dataTreeString = NormalizedNodes.toStringTree(initialDataBI);
             LOG.trace("Initial {} datastore data: {}", datastoreType, dataTreeString);
-        } catch (SerializationException | IOException | ExecutionException | InterruptedException | TimeoutException e) {
+        } catch (SerializationException | IOException | ExecutionException | InterruptedException
+                | TimeoutException e) {
             String msg = "Unable to set initial state of " + datastoreType + " datastore from XML!";
             LOG.error(msg, e);
             throw new IllegalStateException(msg, e);

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
@@ -10,6 +10,7 @@ package io.lighty.netconf.device.requests;
 import io.lighty.codecs.api.SerializationException;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.response.Response;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -88,8 +91,8 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
     }
 
     private Document processResponse(final CompletableFuture<Response> responseOutput)
-            throws ExecutionException, InterruptedException, ParserConfigurationException {
-        final Response listResponse = responseOutput.get();
+            throws ExecutionException, InterruptedException, ParserConfigurationException, TimeoutException {
+        final Response listResponse = responseOutput.get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         final Document error = listResponse.getErrorDocument();
         if (error != null) {
             return error;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
@@ -10,11 +10,14 @@ package io.lighty.netconf.device.requests;
 import com.google.common.util.concurrent.FluentFuture;
 import io.lighty.codecs.api.SerializationException;
 import io.lighty.netconf.device.utils.RPCUtil;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
@@ -46,13 +49,13 @@ public abstract class DatastoreOutputRequestProcessor extends BaseRequestProcess
         try (DOMDataTreeReadTransaction domDataReadOnlyTransaction = domDataBroker.newReadOnlyTransaction()) {
             FluentFuture<Optional<NormalizedNode<?, ?>>> readData =
                     domDataReadOnlyTransaction.read(datastoreType, YangInstanceIdentifier.empty());
-            listData = readData.get();
+            listData = readData.get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
             if (listData.isPresent()) {
                 ContainerNode containerNode = (ContainerNode) listData.get();
                 return new ArrayList<>(containerNode.getValue());
             }
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             LOG.error("Exception thrown while getting data from datastore!", e);
         }
         return Collections.emptyList();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
@@ -16,6 +16,7 @@ import io.lighty.netconf.device.response.ResponseErrorMessage;
 import io.lighty.netconf.device.utils.DefaultOperation;
 import io.lighty.netconf.device.utils.Operation;
 import io.lighty.netconf.device.utils.RPCUtil;
+import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.io.StringReader;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
@@ -28,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
@@ -177,10 +180,10 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
                 break;
         }
         try {
-            writeTx.commit().get();
+            writeTx.commit().get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             responseFuture.complete(new ResponseData(Collections.emptyList()));
             return responseFuture;
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             if (e.getCause() instanceof TransactionCommitFailedException) {
                 final Throwable error = e.getCause();
                 if (error.getCause() instanceof SchemaValidationFailedException) {
@@ -344,8 +347,8 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
 
         try {
             return readTx.exists(LogicalDatastoreType.CONFIGURATION, path)
-                    .get();
-        } catch (InterruptedException | ExecutionException e) {
+                    .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw createTxException(data, e, operationToExecute.getOperationName().toUpperCase(Locale.ROOT));
         }
     }

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/TimeoutUtil.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/TimeoutUtil.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the LIGHTY.IO LICENSE,
+ * version 1.1. If a copy of the license was not distributed with this file,
+ * You can obtain one at https://lighty.io/license/1.1/
+ */
+
+package io.lighty.netconf.device.utils;
+
+public abstract class TimeoutUtil {
+
+    public static final long TIMEOUT_MILLIS = 30;
+
+    private TimeoutUtil() {
+    }
+}


### PR DESCRIPTION
Replace all Future.get() by call with timeout to avoid stuck or lock resources