### PR TITLE
Fix RpcOutputRequestProcessor to correctly reply ok message and ToasterDeviceTest 12.2.x

### DIFF
--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/NotificationNetconfSessionListener.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/NotificationNetconfSessionListener.java
@@ -15,17 +15,24 @@ import org.opendaylight.netconf.client.SimpleNetconfClientSessionListener;
 public class NotificationNetconfSessionListener  extends SimpleNetconfClientSessionListener {
 
     private CountDownLatch countDownLatch;
+    private NetconfMessage receivedNotif;
 
     public NotificationNetconfSessionListener(CountDownLatch countDownLatch) {
         this.countDownLatch = countDownLatch;
+        this.receivedNotif = null;
     }
 
     @Override
     public synchronized void onMessage(final NetconfClientSession session, final NetconfMessage message) {
         super.onMessage(session, message);
         if (isNotification(message)) {
+            this.receivedNotif = message;
             this.countDownLatch.countDown();
         }
+    }
+
+    public NetconfMessage getReceivedNotificationMessage() {
+        return this.receivedNotif;
     }
 
     private boolean isNotification(NetconfMessage message) {

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -9,6 +9,7 @@ package io.lighty.netconf.device.toaster;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.codecs.xml.XmlUtil;
@@ -127,38 +128,56 @@ public class ToasterDeviceTest {
             TimeoutException, IOException {
 
         final CountDownLatch notificationReceivedLatch = new CountDownLatch(1);
-        final SimpleNetconfClientSessionListener sessionListener =
+        final NotificationNetconfSessionListener sessionListenerNotification =
                 new NotificationNetconfSessionListener(notificationReceivedLatch);
-        try (NetconfClientSession session =
-                dispatcher.createClient(createSHHConfig(sessionListener))
-                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
-            final NetconfMessage subscribeResponse =
-                    sentRequestToDevice(SUBSCRIBE_TO_NOTIFICATIONS_REQUEST_XML, sessionListener);
-            assertTrue(containsOkElement(subscribeResponse));
+        final SimpleNetconfClientSessionListener sessionListenerSimple =
+            new SimpleNetconfClientSessionListener();
+
+        try (NetconfClientSession sessionNotification =
+                dispatcher.createClient(createSHHConfig(sessionListenerNotification))
+                        .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            NetconfClientSession sessionSimple =
+                dispatcher.createClient(createSHHConfig(sessionListenerSimple))
+                    .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
 
             final NetconfMessage createToasterResponse =
-                    sentRequestToDevice(CREATE_TOASTER_REQUEST_XML, sessionListener);
+                    sentRequestToDevice(CREATE_TOASTER_REQUEST_XML, sessionListenerSimple);
             assertTrue(containsOkElement(createToasterResponse));
 
             final NetconfMessage toasterData =
-                    sentRequestToDevice(GET_TOASTER_DATA_REQUEST_XML, sessionListener);
+                    sentRequestToDevice(GET_TOASTER_DATA_REQUEST_XML, sessionListenerSimple);
             final String toasterDarknessFactor = toasterData.getDocument()
                     .getDocumentElement().getElementsByTagName("darknessFactor").item(0).getTextContent();
             assertEquals(EXPECTED_DARKNESS_FACTOR, toasterDarknessFactor);
 
-            final NetconfMessage makeToastResponse = sentRequestToDevice(MAKE_TOAST_REQUEST_XML, sessionListener);
+            final NetconfMessage subscribeResponse =
+                sentRequestToDevice(SUBSCRIBE_TO_NOTIFICATIONS_REQUEST_XML, sessionListenerNotification);
+            assertTrue(containsOkElement(subscribeResponse));
+
+            final NetconfMessage makeToastResponse =
+                sentRequestToDevice(MAKE_TOAST_REQUEST_XML, sessionListenerSimple);
             assertTrue(containsOkElement(makeToastResponse));
 
             final NetconfMessage restockToastResponse =
-                    sentRequestToDevice(RESTOCK_TOAST_REQUEST_XML, sessionListener);
+                sentRequestToDevice(RESTOCK_TOAST_REQUEST_XML, sessionListenerSimple);
             assertTrue(containsOkElement(restockToastResponse));
+
             final boolean await = notificationReceivedLatch.await(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             assertTrue(await);
+
+            NetconfMessage restockToastNotification = sessionListenerNotification.getReceivedNotificationMessage();
+            assertNotNull(restockToastNotification);
+            assertTrue(containsNotificationElement(restockToastNotification));
+
         }
     }
 
     private boolean containsOkElement(final NetconfMessage responseMessage) {
         return responseMessage.getDocument().getElementsByTagName("ok").getLength() > 0;
+    }
+
+    private boolean containsNotificationElement(final NetconfMessage responseMessage) {
+        return responseMessage.getDocument().getElementsByTagName("notification").getLength() > 0;
     }
 
     public static NetconfMessage sentRequestToDevice(String requestFileName,

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opendaylight.netconf.api.NetconfMessage;
 import org.opendaylight.netconf.client.NetconfClientDispatcher;
@@ -168,7 +167,6 @@ public class ToasterDeviceTest {
             NetconfMessage restockToastNotification = sessionListenerNotification.getReceivedNotificationMessage();
             assertNotNull(restockToastNotification);
             assertTrue(containsNotificationElement(restockToastNotification));
-
         }
     }
 

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
@@ -65,15 +65,19 @@ public abstract class RpcOutputRequestProcessor extends BaseRequestProcessor {
             List<Node> outputNodes = convertOutputToXmlNodes(responseOutput, builder, newDocument);
             List<Node> outputNodesData = new ArrayList<>();
             NodeList nodeList = outputNodes.get(0).getChildNodes();
-            for (int i = 0; i < nodeList.getLength(); i++) {
-                Node node = nodeList.item(i);
-                Element data = newDocument.createElementNS(
-                    getIdentifier().getNamespace().toString(), node.getNodeName());
-                final int length = node.getChildNodes().getLength();
-                for (int j = 0; j < length; j++) {
-                    data.appendChild(node.getFirstChild());
+            if(nodeList.getLength() < 1) {
+                outputNodesData.add(RPCUtil.createOkNode(newDocument));
+            } else {
+                for (int i = 0; i < nodeList.getLength(); i++) {
+                    Node node = nodeList.item(i);
+                    Element data = newDocument.createElementNS(
+                        getIdentifier().getNamespace().toString(), node.getNodeName());
+                    final int length = node.getChildNodes().getLength();
+                    for (int j = 0; j < length; j++) {
+                        data.appendChild(node.getFirstChild());
+                    }
+                    outputNodesData.add(data);
                 }
-                outputNodesData.add(data);
             }
             // wrap nodes to final document
             List<Node> wrappedOutputNodes = new ArrayList<>();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
@@ -65,13 +65,13 @@ public abstract class RpcOutputRequestProcessor extends BaseRequestProcessor {
             List<Node> outputNodes = convertOutputToXmlNodes(responseOutput, builder, newDocument);
             List<Node> outputNodesData = new ArrayList<>();
             NodeList nodeList = outputNodes.get(0).getChildNodes();
-            if(nodeList.getLength() < 1) {
+            if (nodeList.getLength() < 1) {
                 outputNodesData.add(RPCUtil.createOkNode(newDocument));
             } else {
                 for (int i = 0; i < nodeList.getLength(); i++) {
                     Node node = nodeList.item(i);
                     Element data = newDocument.createElementNS(
-                        getIdentifier().getNamespace().toString(), node.getNodeName());
+                            getIdentifier().getNamespace().toString(), node.getNodeName());
                     final int length = node.getChildNodes().getLength();
                     for (int j = 0; j < length; j++) {
                         data.appendChild(node.getFirstChild());


### PR DESCRIPTION
**RpcOutputRequestProcessor fix**
RpcOutputRequestProcessor was incorrectly interpreting
if reponseOutput is empty or not. Check for emptyness
of rpc output itself was added, if empty ok element is
created for output. This is according to YANG RFC 7950,
if rpc output is empty, ok element is returned.

**ToasterDeviceTest**
tests for Toaster device checks NetconfMessage responses
from requests sent to device. Tests are corrected to contain
two separate sessions and session listeners.

Notification session listener checks incoming
notification in message on separate session.
It runs in separate session to check only
notifications incoming as they were interfering
with rpc-reply in response messages.
If notification arrived, it is stored as a message
in listener's receivedNotification attribute.

Subscription is created on simple session that
sends device RPC requests and expects appropriat
response in message - ok element.