### PR TITLE
Correct lighty-core parent reference in readme

### DIFF
--- a/examples/parents/examples-parent/README.md
+++ b/examples/parents/examples-parent/README.md
@@ -1,5 +1,5 @@
 #examples-parent
 
 This module extends lighty-app-parent module from open source project
-[lighty-core](https://github.com/PANTHEONtech/lighty-core/12.2.x/master/lighty-core/lighty-app-parent/pom.xml)
+[lighty-core](https://github.com/PANTHEONtech/lighty-core/blob/12.2.x/lighty-core/lighty-app-parent/pom.xml)
 by `lighty-netconf-simulator` specific versions used for example NETCONF devices.


### PR DESCRIPTION
Update reference in README pointing to lighty-core parent repository

fixes commit f0a7404b

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>