### PR TITLE
Do not load notification model

### DIFF
--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
@@ -7,7 +7,6 @@
  */
 package io.lighty.netconf.device;
 
-import com.google.common.collect.ImmutableSet;
 import io.lighty.netconf.device.requests.CommitRequestProcessor;
 import io.lighty.netconf.device.requests.DeleteConfigRequestProcessor;
 import io.lighty.netconf.device.requests.EditConfigRequestProcessor;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
@@ -127,12 +127,6 @@ public class NetconfDeviceBuilder {
 
     public NetconfDeviceBuilder withDefaultNotificationProcessor() {
         this.withRequestProcessor(new CreateSubscriptionRequestProcessor());
-        Set<YangModuleInfo> moduleInfo = ImmutableSet.of(
-                org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.netconf.notification._1._0
-                    .rev080714.$YangModuleInfoImpl.getInstance(),
-                org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.types
-                    .rev130715.$YangModuleInfoImpl.getInstance());
-        moduleInfos.addAll(moduleInfo);
         this.creator = new NotificationPublishServiceImpl();
         return this;
     }


### PR DESCRIPTION
According to https://jira.opendaylight.org/browse/NETCONF-338 we don't need notification model.
The notification capability should be enough for notifications to work.

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>