### PR TITLE
Add default NETCONF notification capability

### DIFF
--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
@@ -36,6 +36,7 @@ public class NetconfDeviceBuilder {
     private InputStream initialOperationalData;
     private InputStream initialConfigurationData;
     private Map<QName, RequestProcessor> requestProcessors;
+    private Set<String> allCapabilities;
     private NotificationPublishServiceImpl creator;
     private boolean netconfMonitoringEnabled;
 
@@ -43,6 +44,7 @@ public class NetconfDeviceBuilder {
         this.configurationBuilder = new ConfigurationBuilder();
         this.requestProcessors = new HashMap<>();
         this.moduleInfos = new HashSet<>();
+        this.allCapabilities = new HashSet<>();
         this.netconfMonitoringEnabled = true;
     }
 
@@ -75,7 +77,7 @@ public class NetconfDeviceBuilder {
     }
 
     public NetconfDeviceBuilder withCapabilities(Set<String> capabilities) {
-        this.configurationBuilder.setCapabilities(capabilities);
+        this.allCapabilities.addAll(capabilities);
         return this;
     }
 
@@ -85,7 +87,7 @@ public class NetconfDeviceBuilder {
     }
 
     public NetconfDeviceBuilder withDefaultCapabilities() {
-        this.configurationBuilder.setCapabilities(ModelUtils.DEFAULT_CAPABILITIES);
+        this.allCapabilities.addAll(ModelUtils.DEFAULT_CAPABILITIES);
         return this;
     }
 
@@ -125,6 +127,7 @@ public class NetconfDeviceBuilder {
     }
 
     public NetconfDeviceBuilder withDefaultNotificationProcessor() {
+        this.allCapabilities.add(ModelUtils.DEFAULT_NOTIFICATION_CAPABILITY);
         this.withRequestProcessor(new CreateSubscriptionRequestProcessor());
         this.creator = new NotificationPublishServiceImpl();
         return this;
@@ -159,6 +162,7 @@ public class NetconfDeviceBuilder {
      * @return new implementation of NetconfDevice
      */
     public NetconfDevice build() {
+        this.configurationBuilder.setCapabilities(this.allCapabilities);
         if (netconfMonitoringEnabled) {
             YangModuleInfo netconfMonitoringModule =
                 org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/ModelUtils.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/ModelUtils.java
@@ -23,6 +23,8 @@ public final class ModelUtils {
 
     public static final Set<String> DEFAULT_CAPABILITIES =
             ImmutableSet.of("urn:ietf:params:netconf:base:1.0", "urn:ietf:params:netconf:base:1.1");
+    public static final String DEFAULT_NOTIFICATION_CAPABILITY =
+        "urn:ietf:params:netconf:capability:notification:1.0";
 
     /**
      * Get all Yang modules from classpath filtered by top-level module.


### PR DESCRIPTION
Fixes integration with ODL/lighty through notifications, device should contain capability to inform other devices trying to subscribe on notifications, that the NETCONF device support notifications. relates to https://git.opendaylight.org/gerrit/c/netconf/+/88643 & https://jira.opendaylight.org/browse/NETCONF-338


Add NETCONF notification capability to device
when built with withDefaultNotificationProcesor
method called on NetconfDeviceBuilder.

Added capabilities HashSet to include all modules
from withDefaultCapabilities and withDefaultCapabilities
so if called one after another they won't overwrite currently
set capabilities.
