### PR TITLE
Introduce multiple simulators capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ This tool contains 4 device examples, to demonstrate the usage of the NETCONF De
 - [**lighty Toaster Device**](./examples/devices/lighty-toaster-device/README.md)
 
 [Read about the background of this project here.](https://pantheon.tech/netconf-monitoring-get-schema/)
+
+## Known Issues
+
+**Problem:** Creating multiple simulators takes a long time.  
+ Delay can be caused by Random Number Generation `/dev/random`.   
+**Solution:** Use /dev/urandom instead of /dev/random by passing it as system property  
+`-Djava.security.egd=file:/dev/./urandom` or modify file `$JAVA_HOME/jre/lib/security/java.security`  
+by changing property `securerandom.source=file:/dev/random`
+to `securerandom.source=file:/dev/urandom`.

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
@@ -157,6 +157,12 @@ public class NetconfDeviceBuilder {
         return this;
     }
 
+    // FIXME All created devices share the same datastore. Each simulated devices must have a separate datastore space.
+    public NetconfDeviceBuilder setDeviceCount(int deviceCount) {
+        this.configurationBuilder.setDeviceCount(deviceCount);
+        return this;
+    }
+
     public NetconfDeviceBuilder setThreadPoolSize(int threadPoolSize) {
         this.configurationBuilder.setThreadPoolSize(threadPoolSize);
         return this;


### PR DESCRIPTION
Introduce capability to run multiple simulators in single runtime.

**Issues:** 
- All created devices share the same datastore. If RPC modify datastore for one device, other devices provide same data on get RPCs. Each simulated devices must have a separate datastore space.
- Creating huge number of devices takes a long time: The solution is written in README.md