### PR TITLE
Introduce Toaster multiple devices example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ mvn clean install
 * The build & run procedures for the example devices are described in each device's README.
 
 ## Example NETCONF Device Simulators
-This tool contains 4 device examples, to demonstrate the usage of the NETCONF Device Library for creating custom devices:
+This tool contains 5 device examples, to demonstrate the usage of the NETCONF Device Library for creating custom devices:
 - [**lighty Actions Device**](./examples/devices/lighty-actions-device/README.md)
 - [**lighty Network Topology Device**](./examples/devices/lighty-network-topology-device/README.md)
 - [**lighty Notifications Device**](./examples/devices/lighty-notifications-device/README.md)
 - [**lighty Toaster Device**](./examples/devices/lighty-toaster-device/README.md)
+- [**lighty Toaster Multiple Devices**](./examples/devices/lighty-toaster-multiple-devices/README.md)
 
 [Read about the background of this project here.](https://pantheon.tech/netconf-monitoring-get-schema/)
 

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -1,0 +1,180 @@
+# Toaster multiple devices example
+
+The simulator has the ability to create multiple devices in a single JVM instance. **All devices share the same datastore.**  
+The netconf device uses the toaster yang model `toaster@2009-11-20.yang`.
+
+### Build and run
+Build root project - for more details check: [README](../../../README.md)
+
+**Run device**
+* Extract binary distribution in target directory.
+* Run jar file from zip with parameters. Parameters are optional. If they are not used, the default value is used.  
+`--device-count DEVICES-COUNT` (Default 1) Number of simulated netconf devices to spin. This is the number of actual ports which will be used for the devices. If some ports are bound, these ports will be skipped. The log shows all open ports.    
+`--starting-port STARTING-PORT` (Default 17380) First port for simulated device. Each other device will use incremented port number.    
+`--thread-pool-size THREAD-POOL-SIZE` (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.    
+```
+java -jar lighty-toaster-multiple-devices-13.2.1-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
+```
+
+### Connect to device via SSH
+**Open session**
+
+To connect to a devices via SSH, run command.  
+All devices are accessible via a bound port.
+
+```
+ssh admin@127.0.0.1 -p 20000 -s netconf
+ssh admin@127.0.0.1 -p 20001 -s netconf
+...
+ssh admin@127.0.0.1 -p 20199 -s netconf
+```
+
+where
+- `admin` is default username of a device with password `admin`(no other users)
+- `127.0.0.1` is the local IP address of the machine where device is running
+- `-p 20000` is port number of running device
+- `-s netconf` option establishes the NETCONF session as an SSH subsystem,
+which means that NETCONF can be used in terminal through opened SSH session
+
+To complete connection with a device, it is necessary to initiate handshake by
+sending client's model capabilities in hello-message:
+
+```
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <capabilities>
+        <capability>urn:ietf:params:netconf:base:1.0</capability>
+    </capabilities>
+</hello>
+]]>]]>
+```
+which informs the device which capabilities the client supports.
+The capabilities tag contains list of capabilities the client supports, e.g.
+```
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <capabilities>
+        <capability>capability1</capabaility>
+        <capability>capability2</capabaility>
+        <capability>capability3</capabaility>
+        ...
+    </capabilities>
+</hello>
+]]>]]>
+```
+
+If handshake is not completed by sending hello message with client's capabilities
+and any other message is sent, following error message is received (long text replaced with ...):
+```
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <rpc-error>
+        <error-type>rpc</error-type>
+        <error-tag>malformed-message</error-tag>
+        <error-severity>error</error-severity>
+        <error-message>
+            java.lang.IllegalStateException: Hello message not received, instead received: ...
+        </error-message>
+        <error-info>
+            <cause>
+                java.lang.IllegalStateException: Hello message not received, instead received: ...
+            </cause>
+        </error-info>
+    </rpc-error>
+</rpc-reply>
+]]>]]>
+```
+
+**Close session**
+
+To properly exit current NETCONF device SSH session, close-session message
+needs to be send
+```
+<rpc message-id="106" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <close-session/>
+</rpc>
+]]>]]>
+```
+ok message will be replied and then closed the session.
+```
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="106">
+    <ok/>
+</rpc-reply>
+```
+
+### Basic NETCONF commands
+
+For more information on simulator basic NETCONF commands check: [Basic NETCONF commands](../lighty-toaster-device/README.md#basic-netconf-commands).
+
+### Toaster Model
+YANG model used by the device is toaster@2009-11-20.yang.
+
+The simulator has defined 2 RPCs:
+
+**make-toast**
+
+- takes optional `toasterDoneness` and `toasterToastType` values as an input
+into RPC, if not specified the default values from YANG models will be used.
+
+```
+<rpc message-id="mt1" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <make-toast xmlns="http://netconfcentral.org/ns/toaster">
+        <toasterDoneness>2</toasterDoneness>
+        <toasterToastType>frozen-waffle</toasterToastType>
+     </make-toast>
+</rpc>
+]]>]]>
+```
+
+**cancel-toast**
+
+(has no inputs)
+```
+<rpc message-id="ct1" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <cancel-toast xmlns="http://netconfcentral.org/ns/toaster">
+    </cancel-toast>
+</rpc>
+]]>]]>
+```
+
+After each of the upper RPC calls, appropriate info message can be seen in
+device logs.
+
+Example of log info for make-toast RPC:
+```
+INFO [nioEventLoopGroup-2-3] (ToasterServiceMakeToastProcessor.java:30) - execute RPC: make-toast
+INFO [nioEventLoopGroup-2-3] (ToasterServiceImpl.java:35) - makeToast 2 interface org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.FrozenWaffle
+```
+contains information with what parameters was RPC called:
+`toasterDoneness: 2` and `toasterToastType: frozen-waffle`.
+
+Example of successful reply message:
+```
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+    <rpc-reply message-id="id" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"/>
+]]>]]>
+```
+where message-id corresponds with message-id which RPC was called with, so for
+request with message-id `mt1` the response will contain same message-id `mt1`.
+
+Example of unsuccessful reply contains appropriate error message (e.g. unknown
+toast type: pink-bread)
+
+```
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<rpc-reply message-id="mt1" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <rpc-error>
+        <error-type>application</error-type>
+        <error-tag>operation-failed</error-tag>
+        <error-severity>error</error-severity>
+        <error-message>Unexpected error</error-message>
+        <error-info>
+            <ERROR>java.lang.UnsupportedOperationException:
+                java.lang.IllegalArgumentException:
+                    Parsed QName (http://netconfcentral.org/ns/toaster?revision=2009-11-20)pink-bread
+                    does not refer to a valid identity
+            </ERROR>
+        </error-info>
+    </rpc-error>
+</rpc-reply>
+]]>]]>
+```

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 PANTHEON.tech s.r.o. All Rights Reserved.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v1.0 which accompanies this distribution,
+  and is available at https://www.eclipse.org/legal/epl-v10.html
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lighty.netconf.device.examples</groupId>
+        <artifactId>examples-parent</artifactId>
+        <version>13.2.1-SNAPSHOT</version>
+        <relativePath>../../parents/examples-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>lighty-toaster-multiple-devices</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <application.main.class>io.lighty.netconf.device.toaster.Main</application.main.class>
+        <application.attach.zip>true</application.attach.zip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lighty.models.test</groupId>
+            <artifactId>lighty-toaster</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.netconf.device.examples</groupId>
+            <artifactId>lighty-toaster-device</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright (c) 2021 PANTHEON.tech s.r.o. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v1.0 which accompanies this distribution,
+# and is available at http://www.eclipse.org/legal/epl-v10.html
+#
+# The script accepts parameters specifying the listening port, the number of devices and the number of threads for the NETCONF server.
+# Parameters are optional. If they are not used, the default value is used.
+# --device-count DEVICES-COUNT (Default 1) Number of simulated netconf devices to spin. This is the number of actual ports which will be used for the devices.
+# --starting-port STARTING-PORT (Default 17380) First port for simulated device. Each other device will use incremented port number.
+# --thread-pool-size THREAD-POOL-SIZE (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.
+# ./start-device --starting-port <STARTING_PORT> --device-count <DEVICE_COUNT> --thread-pool-size <THREAD_POOL_SIZE>
+# ./start-device --starting-port 20000 --device-count 200 --thread-pool-size 200
+#
+
+CLASSPATH=lighty-toaster-multiple-devices-13.2.1-SNAPSHOT.jar
+
+ARGUMENT_LIST=(
+    "device-count"
+    "starting-port"
+    "thread-pool-size"
+)
+
+deviceCount=1
+startingPort=17830
+threadPoolSize=8
+
+# read arguments
+opts=$(getopt \
+    --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \
+    --name "$(basename "$0")" \
+    --options "" \
+    -- "$@"
+)
+
+eval set --$opts
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --device-count)
+            deviceCount=$2
+            shift 2
+            ;;
+
+        --starting-port)
+            startingPort=$2
+            shift 2
+            ;;
+
+        --thread-pool-size)
+            threadPoolSize=$2
+            shift 2
+            ;;
+
+        *)
+            break
+            ;;
+    esac
+done
+
+for jar in `ls -1 lib/`;
+do
+   CLASSPATH=$CLASSPATH:lib/$jar
+done
+
+java -server -Xms16M -Xmx40M -XX:MaxMetaspaceSize=40m -classpath $CLASSPATH io.lighty.netconf.device.toaster.Main --starting-port $startingPort --thread-pool-size $threadPoolSize --device-count $deviceCount

--- a/examples/devices/lighty-toaster-multiple-devices/src/main/java/io/lighty/netconf/device/toaster/Main.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/main/java/io/lighty/netconf/device/toaster/Main.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2020 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.netconf.device.toaster;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.lighty.core.common.models.ModuleId;
+import io.lighty.netconf.device.NetconfDevice;
+import io.lighty.netconf.device.NetconfDeviceBuilder;
+import io.lighty.netconf.device.toaster.processors.ToasterServiceCancelToastProcessor;
+import io.lighty.netconf.device.toaster.processors.ToasterServiceMakeToastProcessor;
+import io.lighty.netconf.device.toaster.rpcs.ToasterServiceImpl;
+import io.lighty.netconf.device.utils.ModelUtils;
+import java.io.InputStream;
+import java.util.Set;
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import org.opendaylight.netconf.test.tool.TesttoolParameters;
+import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public final class Main {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+    private ShutdownHook shutdownHook;
+
+    public static void main(String[] args) {
+        Main app = new Main();
+        app.start(args, true, true);
+    }
+
+    @SuppressFBWarnings({"SLF4J_SIGN_ONLY_FORMAT", "OBL_UNSATISFIED_OBLIGATION"})
+    public void start(String[] args, boolean registerShutdownHook, final boolean initDatastore) {
+        //1. Load parameters
+        final TesttoolParameters params = TesttoolParameters.parseArgs(args, getParser());
+
+        LOG.info("Lighty-Toaster device started {}", params.startingPort);
+        LOG.info("___________             __        ________              .__");
+        LOG.info("\\__    ___/___  _______/  |_______\\______ \\   _______  _|__| ____  ____");
+        LOG.info("  |    | /  _ \\/  ___/\\   __\\_  __ \\    |  \\_/ __ \\  \\/ /  |/ ___\\/ __ \\");
+        LOG.info("  |    |(  <_> )___ \\  |  |  |  | \\/    `   \\  ___/\\   /|  \\  \\__\\  ___/");
+        LOG.info("  |____| \\____/____  > |__|  |__| /_______  /\\___  >\\_/ |__|\\___  >___  >");
+        LOG.info("                   \\/                     \\/     \\/             \\/    \\/");
+        LOG.info("[https://lighty.io]");
+
+        //2. Load models from classpath
+        Set<YangModuleInfo> toasterModules = ModelUtils.getModelsFromClasspath(
+                ModuleId.from(
+                        "http://netconfcentral.org/ns/toaster", "toaster", "2009-11-20"));
+
+        //3. Initialize DataStores
+        InputStream initialOperationalData = null;
+        InputStream initialConfigurationData = null;
+        if (initDatastore) {
+            initialOperationalData =
+                    Main.class.getResourceAsStream("/initial-toaster-operational-datastore.xml");
+            initialConfigurationData =
+                    Main.class.getResourceAsStream("/initial-toaster-config-datastore.xml");
+        }
+
+        ToasterServiceImpl toasterService = new ToasterServiceImpl();
+
+        //4. Initialize Netconf device
+        NetconfDevice netconfDevice = new NetconfDeviceBuilder()
+                .setCredentials("admin", "admin")
+                .setBindingPort(params.startingPort)
+                .withModels(toasterModules)
+                .withDefaultRequestProcessors()
+                .withDefaultCapabilities()
+                .withRequestProcessor(new ToasterServiceMakeToastProcessor(toasterService))
+                .withRequestProcessor(new ToasterServiceCancelToastProcessor(toasterService))
+                .setThreadPoolSize(params.threadPoolSize)
+                .setDeviceCount(params.deviceCount)
+                .setInitialOperationalData(initialOperationalData)
+                .setInitialConfigurationData(initialConfigurationData)
+                .build();
+
+        netconfDevice.start();
+
+        //5. Register shutdown hook
+        this.shutdownHook = new ShutdownHook(netconfDevice,toasterService);
+        if (registerShutdownHook) {
+            Runtime.getRuntime().addShutdownHook(this.shutdownHook);
+        }
+    }
+
+    public void shutdown() {
+        if (shutdownHook != null) {
+            shutdownHook.execute();
+        }
+    }
+
+    static ArgumentParser getParser() {
+        final ArgumentParser parser = ArgumentParsers.newFor("netconf").build();
+
+        parser.addArgument("--starting-port")
+                .type(Integer.class)
+                .setDefault(17830)
+                .help("First port for simulated device. Each other device will have previous+1 port number")
+                .dest("starting-port");
+
+        parser.addArgument("--device-count")
+                .type(Integer.class)
+                .setDefault(1)
+                .help("Number of simulated netconf devices to spin."
+                        + " This is the number of actual ports which will be used for the devices.")
+                .dest("devices-count");
+
+        parser.addArgument("--thread-pool-size")
+                .type(Integer.class)
+                .setDefault(8)
+                .help("The number of threads to keep in the pool, "
+                        + "when creating a device simulator, even if they are idle.")
+                .dest("thread-pool-size");
+
+        return parser;
+    }
+
+    private static class ShutdownHook extends Thread {
+
+        private final NetconfDevice netConfDevice;
+        private final ToasterServiceImpl toasterService;
+
+        ShutdownHook(NetconfDevice netConfDevice, ToasterServiceImpl toasterService) {
+            this.netConfDevice = netConfDevice;
+            this.toasterService = toasterService;
+        }
+
+        @Override
+        public void run() {
+            this.execute();
+        }
+
+        @SuppressWarnings("checkstyle:IllegalCatch")
+        public void execute() {
+            LOG.info("Shutting down Lighty-Toaster device.");
+            if (toasterService != null) {
+                toasterService.close();
+            }
+            if (netConfDevice != null) {
+                try {
+                    netConfDevice.close();
+                } catch (Exception e) {
+                    LOG.error("Failed to close Netconf device properly", e);
+                }
+            }
+        }
+    }
+}

--- a/examples/devices/lighty-toaster-multiple-devices/src/main/resources/initial-toaster-config-datastore.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/src/main/resources/initial-toaster-config-datastore.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <toaster xmlns="http://netconfcentral.org/ns/toaster">
+        <darknessFactor>200</darknessFactor>
+    </toaster>
+</data>

--- a/examples/devices/lighty-toaster-multiple-devices/src/main/resources/initial-toaster-operational-datastore.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/src/main/resources/initial-toaster-operational-datastore.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <toaster xmlns="http://netconfcentral.org/ns/toaster">
+        <toasterManufacturer>Pantheon</toasterManufacturer>
+        <toasterModelNumber>SuperToaster9000</toasterModelNumber>
+        <toasterStatus>up</toasterStatus>
+    </toaster>
+</data>

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.netconf.device.toaster;
+
+import static org.testng.Assert.assertTrue;
+
+import io.lighty.netconf.device.utils.TimeoutUtil;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opendaylight.netconf.api.NetconfMessage;
+import org.opendaylight.netconf.api.xml.XmlUtil;
+import org.opendaylight.netconf.client.NetconfClientDispatcher;
+import org.opendaylight.netconf.client.NetconfClientDispatcherImpl;
+import org.opendaylight.netconf.client.NetconfClientSession;
+import org.opendaylight.netconf.client.NetconfClientSessionListener;
+import org.opendaylight.netconf.client.SimpleNetconfClientSessionListener;
+import org.opendaylight.netconf.client.conf.NetconfClientConfiguration;
+import org.opendaylight.netconf.client.conf.NetconfClientConfiguration.NetconfClientProtocol;
+import org.opendaylight.netconf.client.conf.NetconfClientConfigurationBuilder;
+import org.opendaylight.netconf.nettyutil.AbstractNetconfSession;
+import org.opendaylight.netconf.nettyutil.NeverReconnectStrategy;
+import org.opendaylight.netconf.nettyutil.handler.ssh.authentication.LoginPasswordHandler;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class DeviceTest {
+
+    private static final long REQUEST_TIMEOUT_MILLIS = 5_000;
+    private static final String USER = "admin";
+    private static final String PASS = "admin";
+    private static final int DEVICE_STARTING_PORT = 20000;
+    private static final int DEVICE_COUNT = 5;
+    private static final int THREAD_POOL_SIZE = 5;
+    private static final String EXPECTED_DARKNESS_FACTOR = "750";
+    private static final String CREATE_TOASTER_REQUEST_XML = "create_toaster_request.xml";
+    private static final String GET_TOASTER_DATA_REQUEST_XML = "get_toaster_data_request.xml";
+    private static final String MAKE_TOAST_REQUEST_XML = "make_toast_request.xml";
+    public static final String GET_SCHEMAS_REQUEST_XML = "get_schemas_request.xml";
+    private static final List<SimpleNetconfClientSessionListener> SESSION_LISTENERS = new ArrayList<>();
+    private static final List<NetconfClientSession> NETCONF_CLIENT_SESSIONS = new ArrayList<>();
+    private static Main deviceSimulator;
+    private static NioEventLoopGroup nettyGroup;
+
+    @BeforeAll
+    public static void setUpClass() throws InterruptedException, ExecutionException, TimeoutException {
+        deviceSimulator = new Main();
+        deviceSimulator.start(new String[]{"--starting-port",
+                        String.valueOf(DEVICE_STARTING_PORT), "--thread-pool-size",
+                        String.valueOf(THREAD_POOL_SIZE), "--device-count", String.valueOf(DEVICE_COUNT)},
+                true, false);
+        nettyGroup = new NioEventLoopGroup(THREAD_POOL_SIZE, new DefaultThreadFactory(NetconfClientDispatcher.class));
+        NetconfClientDispatcherImpl dispatcher =
+                new NetconfClientDispatcherImpl(nettyGroup, nettyGroup, new HashedWheelTimer());
+        for (int port = DEVICE_STARTING_PORT; port < DEVICE_STARTING_PORT + DEVICE_COUNT; port++) {
+            final SimpleNetconfClientSessionListener sessionListener = new SimpleNetconfClientSessionListener();
+            NetconfClientSession session = dispatcher.createClient(createSHHConfig(sessionListener, port))
+                    .get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            NETCONF_CLIENT_SESSIONS.add(session);
+            SESSION_LISTENERS.add(sessionListener);
+        }
+    }
+
+    @AfterAll
+    public static void cleanUpClass() throws InterruptedException {
+        NETCONF_CLIENT_SESSIONS.forEach(AbstractNetconfSession::close);
+        deviceSimulator.shutdown();
+        nettyGroup.shutdownGracefully().sync();
+    }
+
+    @Test
+    public void sharedDatastoreTest() throws InterruptedException, ExecutionException,
+            TimeoutException, SAXException, IOException, URISyntaxException {
+        final SimpleNetconfClientSessionListener sessionListener = SESSION_LISTENERS.get(0);
+        final NetconfMessage createToasterResponse = sendRequestToDevice(CREATE_TOASTER_REQUEST_XML, sessionListener);
+        assertTrue(containsOkElement(createToasterResponse));
+        for (SimpleNetconfClientSessionListener listener : SESSION_LISTENERS) {
+            final NetconfMessage toasterData = sendRequestToDevice(GET_TOASTER_DATA_REQUEST_XML, listener);
+            final String toasterDarknessFactor = toasterData.getDocument()
+                    .getDocumentElement().getElementsByTagName("darknessFactor").item(0).getTextContent();
+            Assertions.assertEquals(EXPECTED_DARKNESS_FACTOR, toasterDarknessFactor);
+        }
+    }
+
+    @Test
+    public void getSchemaTest() throws IOException, URISyntaxException, SAXException, InterruptedException,
+            ExecutionException, TimeoutException {
+        for (SimpleNetconfClientSessionListener listener : SESSION_LISTENERS) {
+            final NetconfMessage schemaResponse = sendRequestToDevice(GET_SCHEMAS_REQUEST_XML,
+                    listener);
+            final NodeList schema = schemaResponse.getDocument().getDocumentElement().getElementsByTagName("schema");
+            Assertions.assertTrue(schema.getLength() > 0);
+            boolean toasterSchemaContained = false;
+            for (int i = 0; i < schema.getLength(); i++) {
+                if (schema.item(i).getNodeType() == Node.ELEMENT_NODE) {
+                    final Element item = (Element) schema.item(i);
+                    final String schemaName = item.getElementsByTagName("identifier").item(0).getTextContent();
+                    final String schemaNameSpace = item.getElementsByTagName("namespace").item(0).getTextContent();
+                    if ("toaster".equals(schemaName)
+                            && "http://netconfcentral.org/ns/toaster".equals(schemaNameSpace)) {
+                        toasterSchemaContained = true;
+                    }
+                }
+            }
+            Assertions.assertTrue(toasterSchemaContained);
+        }
+    }
+
+    @Test
+    public void toasterRPCsTest() throws ExecutionException, InterruptedException, URISyntaxException, SAXException,
+            TimeoutException, IOException {
+        for (SimpleNetconfClientSessionListener listener : SESSION_LISTENERS) {
+            final NetconfMessage makeToastResponse =
+                    sendRequestToDevice(MAKE_TOAST_REQUEST_XML, listener);
+            Assertions.assertTrue(containsOkElement(makeToastResponse));
+        }
+    }
+
+    private static NetconfClientConfiguration createSHHConfig(final NetconfClientSessionListener sessionListener,
+                                                              Integer port) {
+        return NetconfClientConfigurationBuilder.create()
+                .withAddress(new InetSocketAddress("localhost", port))
+                .withSessionListener(sessionListener)
+                .withReconnectStrategy(new NeverReconnectStrategy(GlobalEventExecutor.INSTANCE,
+                        NetconfClientConfigurationBuilder.DEFAULT_CONNECTION_TIMEOUT_MILLIS))
+                .withProtocol(NetconfClientProtocol.SSH)
+                .withAuthHandler(new LoginPasswordHandler(USER, PASS))
+                .build();
+    }
+
+    private boolean containsOkElement(final NetconfMessage responseMessage) {
+        return responseMessage.getDocument().getElementsByTagName("ok").getLength() > 0;
+    }
+
+    private NetconfMessage sendRequestToDevice(String requestFileName,
+                                               SimpleNetconfClientSessionListener sessionListener)
+            throws SAXException, IOException, URISyntaxException,
+            InterruptedException, ExecutionException, TimeoutException {
+
+        final NetconfMessage requestMessage =
+                new NetconfMessage(XmlUtil.readXmlToDocument(xmlFileToInputStream(requestFileName)));
+
+        return sessionListener.sendRequest(requestMessage).get(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    private InputStream xmlFileToInputStream(final String fileName) throws URISyntaxException, IOException {
+        final URL getRequest = DeviceTest.class.getClassLoader().getResource(fileName);
+        return new FileInputStream(new File(Objects.requireNonNull(getRequest).toURI()));
+    }
+}

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/resources/create_toaster_request.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/resources/create_toaster_request.xml
@@ -1,0 +1,15 @@
+<rpc message-id="m-1" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <edit-config>
+        <target>
+            <running/>
+        </target>
+        <config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <toaster xmlns="http://netconfcentral.org/ns/toaster">
+                <darknessFactor nc:operation="create">750</darknessFactor>
+                <toasterManufacturer nc:operation="create">Pantheon</toasterManufacturer>
+                <toasterModelNumber nc:operation="create">SuperToaster9000</toasterModelNumber>
+                <toasterStatus nc:operation="create">up</toasterStatus>
+            </toaster>
+        </config>
+    </edit-config>
+</rpc>

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/resources/get_schemas_request.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/resources/get_schemas_request.xml
@@ -1,0 +1,9 @@
+<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="m-0">
+    <get>
+        <filter ns0:type="subtree" xmlns:ns0="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <netconf-state xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring">
+                <schemas/>
+            </netconf-state>
+        </filter>
+    </get>
+</rpc>

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/resources/get_toaster_data_request.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/resources/get_toaster_data_request.xml
@@ -1,0 +1,7 @@
+<rpc message-id="m-2" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <get-config>
+        <source>
+            <running/>
+        </source>
+    </get-config>
+</rpc>

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/resources/make_toast_request.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/resources/make_toast_request.xml
@@ -1,0 +1,6 @@
+<rpc message-id="mt1" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <make-toast xmlns="http://netconfcentral.org/ns/toaster">
+        <toasterDoneness>2</toasterDoneness>
+        <toasterToastType>frozen-waffle</toasterToastType>
+    </make-toast>
+</rpc>

--- a/examples/devices/pom.xml
+++ b/examples/devices/pom.xml
@@ -20,6 +20,7 @@
         <module>lighty-actions-device</module>
         <module>lighty-toaster-device</module>
         <module>lighty-network-topology-device</module>
+        <module>lighty-toaster-multiple-devices</module>
         <module>lighty-notifications-device</module>
     </modules>
 

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -54,6 +54,11 @@
                 <version>13.2.1-SNAPSHOT</version>
             </dependency>
             <dependency>
+                <groupId>io.lighty.netconf.device.examples</groupId>
+                <artifactId>lighty-toaster-multiple-devices</artifactId>
+                <version>13.2.1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-notifications-model</artifactId>
                 <version>13.2.1-SNAPSHOT</version>


### PR DESCRIPTION
Ligthy-toaster-multiple-devices example extends lighty-toaster-device
and add the ability to create multiple devices in single JVM.

All devices share the same datastore.
Example accepts parameters for specifying starting port, the number of devices and the number of threads
The Bash script was created, accepts the same parameters.

Fixed examples-bom pom.xml, fix wrong groupid for examples of devices