### PR TITLE
Prepare for release 14.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mvn clean install
 ```
 * The NETCONF Device Library build is located at:
 
-`lighty-netconf-device\target\lighty-netconf-device-13.2.1-SNAPSHOT.jar`
+`lighty-netconf-device\target\lighty-netconf-device-14.0.0.jar`
 
 * The build & run procedures for the example devices are described in each device's README.
 

--- a/examples/devices/lighty-actions-device/README.md
+++ b/examples/devices/lighty-actions-device/README.md
@@ -28,12 +28,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-action-device-13.2.1-SNAPSHOT.jar
+java -jar lighty-action-device-14.0.0.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-action-device-13.2.1-SNAPSHOT.jar 12345
+java -jar lighty-action-device-14.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>13.2.1-SNAPSHOT</version>
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-action-device-13.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-action-device-14.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -19,12 +19,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-network-topology-device-13.2.1-SNAPSHOT.jar
+java -jar lighty-network-topology-device-14.0.0.jar
 ```
 * to run device on specific port it is necessary to add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-network-topology-device-13.2.1-SNAPSHOT.jar 12345
+java -jar lighty-network-topology-device-14.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>13.2.1-SNAPSHOT</version>
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-network-topology-device-13.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-network-topology-device-14.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
@@ -53,8 +53,8 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
                     xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
 
             //2. convert NormalizedNode<?, ?> into RPC input
-            final T input = dataCodec.convertToBindingAwareRpc(getRpcDefinition().getInput().getPath(),
-                    (ContainerNode) deserializedNode);
+            final T input = dataCodec.convertToBindingAwareRpc(
+                    getRpcDefinition().getInput().getPath().asAbsolute(), (ContainerNode) deserializedNode);
 
             //3. invoke RPC
             final RpcResult<O> rpcResult = execMethod(input);

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/rpcs/NetworkTopologyServiceImpl.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/rpcs/NetworkTopologyServiceImpl.java
@@ -527,7 +527,7 @@ public final class NetworkTopologyServiceImpl implements NetworkTopologyRpcsServ
             .network.topology.topology.NodeBuilder()
                 .withKey(nk)
                 .setNodeId(node.getNodeId())
-                .addAugmentation(NetconfNode.class, ncNode)
+                .addAugmentation(ncNode)
                 .build();
     }
 

--- a/examples/devices/lighty-notifications-device/README.md
+++ b/examples/devices/lighty-notifications-device/README.md
@@ -10,16 +10,16 @@ Check commands in [Notifications device model](#notifications-device-model) on h
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-notifications-device-13.2.1-SNAPSHOT-bin.zip`
+* extract binary distribution `lighty-notifications-device-14.0.0-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-notifications-device-13.2.1-SNAPSHOT.jar
+java -jar lighty-notifications-device-14.0.0.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-notifications-device-13.2.1-SNAPSHOT.jar 12345
+java -jar lighty-notifications-device-14.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-notifications-device/pom.xml
+++ b/examples/devices/lighty-notifications-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>13.2.1-SNAPSHOT</version>
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-notifications-device/pom.xml
+++ b/examples/devices/lighty-notifications-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-notifications-device-13.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-notifications-device-14.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-notifications-device/src/main/java/io/lighty/netconf/device/notification/processors/TriggerNotificationProcessor.java
+++ b/examples/devices/lighty-notifications-device/src/main/java/io/lighty/netconf/device/notification/processors/TriggerNotificationProcessor.java
@@ -64,7 +64,7 @@ public class TriggerNotificationProcessor extends RpcOutputRequestProcessor {
                 final NormalizedNode<?, ?> deserializedNode =
                         xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
                 final TriggerDataNotificationInput input = this.dataCodec
-                        .convertToBindingAwareRpc(getRpcDefinition().getInput().getPath(),
+                        .convertToBindingAwareRpc(getRpcDefinition().getInput().getPath().asAbsolute(),
                                 (ContainerNode) deserializedNode);
 
                 final DataNotification notification = createNotification(input);

--- a/examples/devices/lighty-toaster-device/README.md
+++ b/examples/devices/lighty-toaster-device/README.md
@@ -13,16 +13,16 @@ of the processor calls method of `ToasterServiceImpl` which implements
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-toaster-device-13.2.1-SNAPSHOT-bin.zip`
+* extract binary distribution `lighty-toaster-device-14.0.0-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-toaster-device-13.2.1-SNAPSHOT.jar
+java -jar lighty-toaster-device-14.0.0.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-toaster-device-13.2.1-SNAPSHOT.jar 12345
+java -jar lighty-toaster-device-14.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-device/pom.xml
+++ b/examples/devices/lighty-toaster-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>13.2.1-SNAPSHOT</version>
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-device/pom.xml
+++ b/examples/devices/lighty-toaster-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-toaster-device-13.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-toaster-device-14.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
+++ b/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
@@ -55,8 +55,8 @@ public abstract class ToasterServiceAbstractProcessor<I extends DataObject, O ex
                     xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
 
             //2. convert NormalizedNode<?, ?> into RPC input
-            final I input = this.dataCodec.convertToBindingAwareRpc(getRpcDefinition().getInput().getPath(),
-                    (ContainerNode) deserializedNode);
+            final I input = this.dataCodec.convertToBindingAwareRpc(
+                    getRpcDefinition().getInput().getPath().asAbsolute(), (ContainerNode) deserializedNode);
 
             //3. invoke RPC and wait for completion
             final Future<RpcResult<O>> invokeRpc = execMethod(input);

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -13,7 +13,7 @@ Build root project - for more details check: [README](../../../README.md)
 `--starting-port STARTING-PORT` (Default 17380) First port for simulated device. Each other device will use incremented port number.    
 `--thread-pool-size THREAD-POOL-SIZE` (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.    
 ```
-java -jar lighty-toaster-multiple-devices-13.2.1-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
+java -jar lighty-toaster-multiple-devices-14.0.0.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>13.2.1-SNAPSHOT</version>
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
@@ -15,7 +15,7 @@
 # ./start-device --starting-port 20000 --device-count 200 --thread-pool-size 200
 #
 
-CLASSPATH=lighty-toaster-multiple-devices-13.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-toaster-multiple-devices-14.0.0.jar
 
 ARGUMENT_LIST=(
     "device-count"

--- a/examples/devices/pom.xml
+++ b/examples/devices/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>devices-aggregator</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/devices/pom.xml
+++ b/examples/devices/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>devices-aggregator</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -12,7 +12,6 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <!-- FIXME: Change to release version when will be available -->
         <version>14.0.0</version>
         <relativePath/>
     </parent>

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -13,11 +13,11 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
         <!-- FIXME: Change to release version when will be available -->
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-data-center-model</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
 </project>

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -12,11 +12,12 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.2.0</version>
+        <!-- FIXME: Change to release version when will be available -->
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-data-center-model</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
 </project>

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -12,7 +12,6 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <!-- FIXME: Change to release version when will be available -->
         <version>14.0.0</version>
     </parent>
 

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -13,12 +13,12 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
         <!-- FIXME: Change to release version when will be available -->
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-network-topology-device-model</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
 
     <dependencies>
         <dependency>

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -12,12 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.2.0</version>
+        <!-- FIXME: Change to release version when will be available -->
+        <version>14.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-network-topology-device-model</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -12,11 +12,12 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.2.0</version>
+        <!-- FIXME: Change to release version when will be available -->
+        <version>14.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-notifications-model</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
 
 </project>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -13,11 +13,11 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
         <!-- FIXME: Change to release version when will be available -->
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-notifications-model</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
 
 </project>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -12,7 +12,6 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <!-- FIXME: Change to release version when will be available -->
         <version>14.0.0</version>
     </parent>
 

--- a/examples/models/pom.xml
+++ b/examples/models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/models/pom.xml
+++ b/examples/models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-bom</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,42 +26,42 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-network-topology-device-model</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-data-center-model</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device</groupId>
                 <artifactId>lighty-netconf-device</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-actions-device</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-device</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-network-topology-device</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-multiple-devices</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-notifications-model</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-bom</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,42 +26,42 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-network-topology-device-model</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-data-center-model</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device</groupId>
                 <artifactId>lighty-netconf-device</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-actions-device</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-device</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-network-topology-device</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-multiple-devices</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-notifications-model</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
             </dependency>
 
             <dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -14,13 +14,14 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.2.0</version>
+        <!-- FIXME: Change to release version when will be available -->
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -45,7 +46,7 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>examples-bom</artifactId>
-                <version>13.2.1-SNAPSHOT</version>
+                <version>14.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -15,13 +15,13 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
         <!-- FIXME: Change to release version when will be available -->
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
         <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>examples-bom</artifactId>
-                <version>14.0.0-SNAPSHOT</version>
+                <version>14.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -14,7 +14,6 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <!-- FIXME: Change to release version when will be available -->
         <version>14.0.0</version>
         <relativePath/>
     </parent>

--- a/examples/parents/pom.xml
+++ b/examples/parents/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.netconf.device.examples.parents</groupId>
     <artifactId>parents-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
 
     <modules>
         <module>examples-parent</module>

--- a/examples/parents/pom.xml
+++ b/examples/parents/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.netconf.device.examples.parents</groupId>
     <artifactId>parents-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
 
     <modules>
         <module>examples-parent</module>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
 
     <modules>
         <module>parents</module>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
 
     <modules>
         <module>parents</module>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -14,7 +14,6 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <!-- FIXME: Change to release version when will be available -->
         <version>14.0.0</version>
     </parent>
 

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -15,12 +15,12 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
         <!-- FIXME: Change to release version when will be available -->
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>lighty-netconf-device</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -14,12 +14,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.2.0</version>
+        <!-- FIXME: Change to release version when will be available -->
+        <version>14.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>lighty-netconf-device</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
@@ -49,7 +49,7 @@ import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNodes;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
-import org.opendaylight.yangtools.yang.model.api.Module;
+import org.opendaylight.yangtools.yang.model.api.ModuleLike;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,11 +144,11 @@ public class NetconfDeviceImpl implements NetconfDevice {
         EffectiveModelContext modelContext =
             netconfDeviceServices.getAdapterContext()
                 .currentSerializer().getRuntimeContext().getEffectiveModelContext();
-        Queue<Collection<? extends Module>> queueModulesCollections = new LinkedList<>();
+        Queue<Collection<? extends ModuleLike>> queueModulesCollections = new LinkedList<>();
         queueModulesCollections.add(modelContext.getModules());
         while (!queueModulesCollections.isEmpty()) {
-            Collection<? extends Module> modules = queueModulesCollections.poll();
-            for (Module module : modules) {
+            Collection<? extends ModuleLike> modules = queueModulesCollections.poll();
+            for (ModuleLike module : modules) {
                 Schema schema = createSchemaFromModule(module);
                 if (!mapSchemas.containsKey(schema.key())) {
                     mapSchemas.put(schema.key(), schema);
@@ -170,7 +170,7 @@ public class NetconfDeviceImpl implements NetconfDevice {
      * @param module represents module from which schema will be created
      * @return schema created from module parameter
      */
-    private Schema createSchemaFromModule(Module module) {
+    private Schema createSchemaFromModule(ModuleLike module) {
         return new SchemaBuilder()
             .setNamespace(new Uri(module.getNamespace().toString()))
             .setFormat(Yang.class)

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>netconf-device-aggregator</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>netconf-device-aggregator</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
- Use EffectiveModelContext instead of SchemaContext.
- Remove ModuleInfoBackedContext and use instead ModuleInfoSnapshotResolver

Release notes:
- FIX groupid for device examples in example-bom
- Introduce Toaster multiple devices example

Update upstream dependencies to the latest Silicon versions:
- lighty.core 14.0.0
- netconf notification 1.13.0
- netconf testtool 1.13.0