### PR TITLE
Change xml factories initialization - Remove vulnerability to XXE attacks

### DIFF
--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/NotificationOperation.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/NotificationOperation.java
@@ -80,7 +80,9 @@ public class NotificationOperation implements SessionAwareNetconfOperation {
             try {
                 writer = xmlNodeConverter.serializeRpc(notificationDefinition.get(), containerNode);
                 try (InputStream is = new ByteArrayInputStream(writer.toString().getBytes(StandardCharsets.UTF_8))) {
-                    final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                    final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+                    documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                    final DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
                     final Document notification = builder.parse(is);
                     final Element body =
                         notification.createElementNS(RPCUtil.CREATE_SUBSCRIPTION_NAMESPACE,

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -57,6 +58,13 @@ public final class RPCUtil {
     public static final String NETCONF_BASE_NAMESPACE = "urn:ietf:params:xml:ns:netconf:base:1.0";
     public static final String CREATE_SUBSCRIPTION_NAMESPACE = "urn:ietf:params:xml:ns:netconf:notification:1.0";
 
+    private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
+
+    static {
+        TRANSFORMER_FACTORY.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        TRANSFORMER_FACTORY.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    }
+
     /**
      * Transform {@link Element} instance into {@link Reader}.
      * @param requestXmlElement
@@ -67,7 +75,7 @@ public final class RPCUtil {
      *     In case transformation fails;
      */
     public static Reader createReaderFromElement(Element requestXmlElement) throws TransformerException {
-        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
         StringWriter sw = new StringWriter();
         StreamResult sr = new StreamResult(sw);
         DOMSource domSource = new DOMSource(requestXmlElement);
@@ -104,7 +112,7 @@ public final class RPCUtil {
      */
     public static String formatXml(Element xml) {
         try {
-            Transformer tf = TransformerFactory.newInstance().newTransformer();
+            Transformer tf = TRANSFORMER_FACTORY.newTransformer();
             tf.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
             tf.setOutputProperty(OutputKeys.INDENT, "yes");
             Writer outWriter = new StringWriter();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
@@ -61,6 +61,10 @@ public final class RPCUtil {
     private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
 
     static {
+        // When parsing the XML file, the content of the external entities is retrieved from an external storage such as
+        // the file system or network, which may lead, if no restrictions are put in place, to arbitrary file
+        // disclosures or server-side request forgery (SSRF) vulnerabilities.
+        // https://rules.sonarsource.com/java/RSPEC-2755
         TRANSFORMER_FACTORY.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         TRANSFORMER_FACTORY.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
     }


### PR DESCRIPTION
Change xml factories initialization to remove vulnerability to XXE attacks

https://rules.sonarsource.com/java/RSPEC-2755
>When parsing the XML file, the content of the external entities is retrieved from an external storage such as the file system or network, which may lead, if no restrictions are put in place, to arbitrary file disclosures or server-side request forgery (SSRF) vulnerabilities.