### PR TITLE
Prepare release 15.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mvn clean install
 ```
 * The NETCONF Device Library build is located at:
 
-`lighty-netconf-device\target\lighty-netconf-device-14.2.1-SNAPSHOT.jar`
+`lighty-netconf-device\target\lighty-netconf-device-15.0.0-SNAPSHOT.jar`
 
 * The build & run procedures for the example devices are described in each device's README.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mvn clean install
 ```
 * The NETCONF Device Library build is located at:
 
-`lighty-netconf-device\target\lighty-netconf-device-14.2.0.jar`
+`lighty-netconf-device\target\lighty-netconf-device-14.2.1-SNAPSHOT.jar`
 
 * The build & run procedures for the example devices are described in each device's README.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mvn clean install
 ```
 * The NETCONF Device Library build is located at:
 
-`lighty-netconf-device\target\lighty-netconf-device-15.0.0-SNAPSHOT.jar`
+`lighty-netconf-device\target\lighty-netconf-device-15.0.0.jar`
 
 * The build & run procedures for the example devices are described in each device's README.
 

--- a/examples/devices/lighty-actions-device/README.md
+++ b/examples/devices/lighty-actions-device/README.md
@@ -28,12 +28,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-action-device-14.2.1-SNAPSHOT.jar
+java -jar lighty-action-device-15.0.0-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-action-device-14.2.1-SNAPSHOT.jar 12345
+java -jar lighty-action-device-15.0.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-actions-device/README.md
+++ b/examples/devices/lighty-actions-device/README.md
@@ -28,12 +28,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-action-device-15.0.0-SNAPSHOT.jar
+java -jar lighty-action-device-15.0.0.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-action-device-15.0.0-SNAPSHOT.jar 12345
+java -jar lighty-action-device-15.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-actions-device/README.md
+++ b/examples/devices/lighty-actions-device/README.md
@@ -28,12 +28,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-action-device-14.2.0.jar
+java -jar lighty-action-device-14.2.1-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-action-device-14.2.0.jar 12345
+java -jar lighty-action-device-14.2.1-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>15.0.0-SNAPSHOT</version>
+        <version>15.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.2.1-SNAPSHOT</version>
+        <version>15.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-action-device-14.2.0.jar
+CLASSPATH=lighty-action-device-14.2.1-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-action-device-15.0.0-SNAPSHOT.jar
+CLASSPATH=lighty-action-device-15.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-action-device-14.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-action-device-15.0.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ActionServiceDeviceProcessor.java
+++ b/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ActionServiceDeviceProcessor.java
@@ -12,7 +12,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.action.actions.ResetAction;
 import io.lighty.netconf.device.action.actions.StartAction;

--- a/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ActionServiceDeviceProcessor.java
+++ b/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ActionServiceDeviceProcessor.java
@@ -83,7 +83,7 @@ public class ActionServiceDeviceProcessor extends BaseRequestProcessor {
     }
 
     @Override
-    protected Document wrapToFinalDocumentReply(final List<NormalizedNode<?, ?>> responseOutput)
+    protected Document wrapToFinalDocumentReply(final List<NormalizedNode> responseOutput)
             throws ParserConfigurationException {
         final DocumentBuilder builder = getDocumentBuilderFactory().newDocumentBuilder();
         final Document newDocument = builder.newDocument();
@@ -120,7 +120,7 @@ public class ActionServiceDeviceProcessor extends BaseRequestProcessor {
     }
 
     @Override
-    protected String convertNormalizedNodeToXmlString(final NormalizedNode<?, ?> normalizedNode)
+    protected String convertNormalizedNodeToXmlString(final NormalizedNode normalizedNode)
             throws SerializationException {
         return getNetconfDeviceServices().getXmlNodeConverter().serializeRpc(this.actionProcessor.getActionDefinition()
                 .getOutput(),

--- a/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ResetActionProcessor.java
+++ b/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ResetActionProcessor.java
@@ -11,9 +11,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.lighty.codecs.DataCodec;
-import io.lighty.codecs.XmlNodeConverter;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
+import io.lighty.codecs.util.XmlNodeConverter;
 import io.lighty.netconf.device.response.Response;
 import io.lighty.netconf.device.response.ResponseData;
 import io.lighty.netconf.device.utils.RPCUtil;
@@ -24,9 +23,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import javax.xml.transform.TransformerException;
+import org.opendaylight.mdsal.binding.dom.adapter.ConstantAdapterContext;
+import org.opendaylight.mdsal.binding.dom.adapter.CurrentAdapterSerializer;
 import org.opendaylight.mdsal.binding.dom.codec.spi.BindingDOMCodecServices;
 import org.opendaylight.netconf.api.DocumentedException;
-import org.opendaylight.netconf.api.xml.MissingNameSpaceException;
 import org.opendaylight.netconf.api.xml.XmlElement;
 import org.opendaylight.yang.gen.v1.urn.example.data.center.rev180807.Server;
 import org.opendaylight.yang.gen.v1.urn.example.data.center.rev180807.ServerKey;
@@ -51,15 +51,15 @@ public class ResetActionProcessor extends ActionServiceDeviceProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResetActionProcessor.class);
 
-    @SuppressWarnings("rawtypes")
-    private final DataCodec dataCodec;
+    private final CurrentAdapterSerializer adapterSerializer;
     private ActionDefinition actionDefinition;
     private final Reset resetAction;
 
     @SuppressWarnings("rawtypes")
     public ResetActionProcessor(final Reset resetAction, final BindingDOMCodecServices codecServices) {
         this.resetAction = resetAction;
-        this.dataCodec = new DataCodec(codecServices);
+        final ConstantAdapterContext constantAdapterContext = new ConstantAdapterContext(codecServices);
+        this.adapterSerializer = constantAdapterContext.currentSerializer();
     }
 
     @SuppressWarnings({"rawtypes", "unchecked", "checkstyle:IllegalCatch"})
@@ -75,7 +75,7 @@ public class ResetActionProcessor extends ActionServiceDeviceProcessor {
             final Reader readerFromElement = RPCUtil.createReaderFromElement(actionElement);
             final ContainerNode deserializedNode = (ContainerNode) xmlNodeConverter.deserialize(this.actionDefinition
                     .getInput(), readerFromElement);
-            final Input input = this.dataCodec.getCodec().fromNormalizedNodeActionInput(Reset.class, deserializedNode);
+            final Input input = this.adapterSerializer.fromNormalizedNodeActionInput(Reset.class, deserializedNode);
             final String key = findNameElement(xmlElement);
             Preconditions.checkNotNull(key);
             final Class listItem = Server.class;
@@ -90,7 +90,7 @@ public class ResetActionProcessor extends ActionServiceDeviceProcessor {
 
                 @Override
                 public void onSuccess(final RpcResult<Output> result) {
-                    final NormalizedNode domOutput = ResetActionProcessor.this.dataCodec.getCodec()
+                    final NormalizedNode domOutput = ResetActionProcessor.this.adapterSerializer
                             .toNormalizedNodeActionOutput(Reset.class, result.getResult());
                     final List<NormalizedNode> list = new ArrayList<>();
                     list.add(domOutput);
@@ -107,8 +107,7 @@ public class ResetActionProcessor extends ActionServiceDeviceProcessor {
         }
     }
 
-    private String findNameElement(final XmlElement xmlElement) throws DocumentedException,
-        MissingNameSpaceException {
+    private String findNameElement(final XmlElement xmlElement) throws DocumentedException {
         final NodeList elementsByTagName = xmlElement.getDomElement().getOwnerDocument().getElementsByTagName("name");
         final Node item = elementsByTagName.item(0);
         return item.getFirstChild().getNodeValue();

--- a/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ResetActionProcessor.java
+++ b/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ResetActionProcessor.java
@@ -90,9 +90,9 @@ public class ResetActionProcessor extends ActionServiceDeviceProcessor {
 
                 @Override
                 public void onSuccess(final RpcResult<Output> result) {
-                    final NormalizedNode<?, ?> domOutput = ResetActionProcessor.this.dataCodec.getCodec()
+                    final NormalizedNode domOutput = ResetActionProcessor.this.dataCodec.getCodec()
                             .toNormalizedNodeActionOutput(Reset.class, result.getResult());
-                    final List<NormalizedNode<?, ?>> list = new ArrayList<>();
+                    final List<NormalizedNode> list = new ArrayList<>();
                     list.add(domOutput);
                     completableFuture.complete(new ResponseData(list));
                 }

--- a/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/StartActionProcessor.java
+++ b/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/StartActionProcessor.java
@@ -72,9 +72,9 @@ public class StartActionProcessor extends ActionServiceDeviceProcessor {
 
                 @Override
                 public void onSuccess(final RpcResult<Output> result) {
-                    final NormalizedNode<?, ?> domOutput = StartActionProcessor.this.dataCodec.getCodec()
+                    final NormalizedNode domOutput = StartActionProcessor.this.dataCodec.getCodec()
                             .toNormalizedNodeActionOutput(Start.class, result.getResult());
-                    final List<NormalizedNode<?, ?>> list = new ArrayList<>();
+                    final List<NormalizedNode> list = new ArrayList<>();
                     list.add(domOutput);
                     completableFuture.complete(new ResponseData(list));
                 }

--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -19,12 +19,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-network-topology-device-15.0.0-SNAPSHOT.jar
+java -jar lighty-network-topology-device-15.0.0.jar
 ```
 * to run device on specific port it is necessary to add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-network-topology-device-15.0.0-SNAPSHOT.jar 12345
+java -jar lighty-network-topology-device-15.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -19,12 +19,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-network-topology-device-14.2.1-SNAPSHOT.jar
+java -jar lighty-network-topology-device-15.0.0-SNAPSHOT.jar
 ```
 * to run device on specific port it is necessary to add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-network-topology-device-14.2.1-SNAPSHOT.jar 12345
+java -jar lighty-network-topology-device-15.0.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -19,12 +19,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-network-topology-device-14.2.0.jar
+java -jar lighty-network-topology-device-14.2.1-SNAPSHOT.jar
 ```
 * to run device on specific port it is necessary to add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-network-topology-device-14.2.0.jar 12345
+java -jar lighty-network-topology-device-14.2.1-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>15.0.0-SNAPSHOT</version>
+        <version>15.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.2.1-SNAPSHOT</version>
+        <version>15.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-network-topology-device-14.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-network-topology-device-15.0.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-network-topology-device-15.0.0-SNAPSHOT.jar
+CLASSPATH=lighty-network-topology-device-15.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-network-topology-device-14.2.0.jar
+CLASSPATH=lighty-network-topology-device-14.2.1-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
@@ -48,12 +48,12 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
         try (Reader readerFromElement = RPCUtil.createReaderFromElement(requestXmlElement)) {
             final XmlNodeConverter xmlNodeConverter = getNetconfDeviceServices().getXmlNodeConverter();
 
-            //1. convert XML input into NormalizedNode<?, ?>
+            //1. convert XML input into NormalizedNode
 
-            final NormalizedNode<?, ?> deserializedNode =
+            final NormalizedNode deserializedNode =
                     xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
 
-            //2. convert NormalizedNode<?, ?> into RPC input
+            //2. convert NormalizedNode into RPC input
             final T input = dataCodec.convertToBindingAwareRpc(
                     getRpcDefinition().getInput().getPath().asAbsolute(), (ContainerNode) deserializedNode);
 

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
@@ -7,9 +7,8 @@
  */
 package io.lighty.netconf.device.topology.processors;
 
-import io.lighty.codecs.DataCodec;
-import io.lighty.codecs.XmlNodeConverter;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
+import io.lighty.codecs.util.XmlNodeConverter;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.requests.RpcOutputRequestProcessor;
 import io.lighty.netconf.device.response.Response;
@@ -22,11 +21,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import javax.xml.transform.TransformerException;
+import org.opendaylight.mdsal.binding.dom.adapter.ConstantAdapterContext;
+import org.opendaylight.mdsal.binding.dom.adapter.CurrentAdapterSerializer;
 import org.opendaylight.yangtools.yang.binding.DataContainer;
 import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.common.RpcResult;
 import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier.Absolute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -35,12 +37,14 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
     extends RpcOutputRequestProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(NetworkTopologyServiceAbstractProcessor.class);
-    private DataCodec<T> dataCodec;
+    private CurrentAdapterSerializer adapterSerializer;
 
     @Override
     public void init(final NetconfDeviceServices netconfDeviceServices) {
         super.init(netconfDeviceServices);
-        dataCodec = new DataCodec<>(netconfDeviceServices.getAdapterContext().currentSerializer());
+        final ConstantAdapterContext constantAdapterContext
+                = new ConstantAdapterContext(netconfDeviceServices.getAdapterContext().currentSerializer());
+        this.adapterSerializer = constantAdapterContext.currentSerializer();
     }
 
     @Override
@@ -54,15 +58,15 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
                     xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
 
             //2. convert NormalizedNode into RPC input
-            final T input = dataCodec.convertToBindingAwareRpc(
-                    getRpcDefinition().getInput().getPath().asAbsolute(), (ContainerNode) deserializedNode);
+            final T input = convertToBindingAwareRpc(getRpcDefinition().getInput().getPath().asAbsolute(),
+                    (ContainerNode) deserializedNode);
 
             //3. invoke RPC
             final RpcResult<O> rpcResult = execMethod(input);
             final DataContainer result = rpcResult.getResult();
 
             //4. convert RPC output to ContainerNode
-            final ContainerNode containerNode = dataCodec.convertToBindingIndependentRpc(result);
+            final ContainerNode containerNode = this.adapterSerializer.toNormalizedNodeRpcData(result);
 
             //5. create response
             final ResponseData responseData;
@@ -85,4 +89,9 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
 
     protected abstract RpcResult<O> execMethod(T input)
             throws ExecutionException, InterruptedException, TimeoutException;
+
+    @SuppressWarnings("unchecked")
+    public T convertToBindingAwareRpc(final Absolute absolute, final ContainerNode rpcData) {
+        return (T) this.adapterSerializer.fromNormalizedNodeRpcData(absolute, rpcData);
+    }
 }

--- a/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
+++ b/examples/devices/lighty-network-topology-device/src/main/java/io/lighty/netconf/device/topology/processors/NetworkTopologyServiceAbstractProcessor.java
@@ -70,7 +70,7 @@ public abstract class NetworkTopologyServiceAbstractProcessor<T extends DataObje
 
             //5. create response
             final ResponseData responseData;
-            if (containerNode.getValue().isEmpty()) {
+            if (containerNode.body().isEmpty()) {
                 responseData = new ResponseData(Collections.emptyList());
             } else {
                 responseData = new ResponseData(Collections.singletonList(containerNode));

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -141,8 +141,14 @@ public class DeviceTest {
 
             final NodeList topologies = getConfigDataResponse.getDocument().getElementsByTagName("topology");
             assertEquals(topologies.getLength(), 2);
-            assertEquals(getTopologyID(topologies.item(0)), "test-config-topology");
-            assertEquals(getTopologyID(topologies.item(1)), "test-config-topology-merge");
+            if (getTopologyID(topologies.item(0)).equals("test-config-topology")) {
+                assertEquals(getTopologyID(topologies.item(0)), "test-config-topology");
+                assertEquals(getTopologyID(topologies.item(1)), "test-config-topology-merge");
+            } else {
+                assertEquals(getTopologyID(topologies.item(1)), "test-config-topology");
+                assertEquals(getTopologyID(topologies.item(0)), "test-config-topology-merge");
+            }
+
             final NodeList nodes = getConfigDataResponse.getDocument().getElementsByTagName("node");
             assertEquals(nodes.getLength(), 1);
 

--- a/examples/devices/lighty-notifications-device/README.md
+++ b/examples/devices/lighty-notifications-device/README.md
@@ -10,16 +10,16 @@ Check commands in [Notifications device model](#notifications-device-model) on h
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-notifications-device-14.2.1-SNAPSHOT-bin.zip`
+* extract binary distribution `lighty-notifications-device-15.0.0-SNAPSHOT-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-notifications-device-14.2.1-SNAPSHOT.jar
+java -jar lighty-notifications-device-15.0.0-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-notifications-device-14.2.1-SNAPSHOT.jar 12345
+java -jar lighty-notifications-device-15.0.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-notifications-device/README.md
+++ b/examples/devices/lighty-notifications-device/README.md
@@ -10,16 +10,16 @@ Check commands in [Notifications device model](#notifications-device-model) on h
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-notifications-device-15.0.0-SNAPSHOT-bin.zip`
+* extract binary distribution `lighty-notifications-device-15.0.0-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-notifications-device-15.0.0-SNAPSHOT.jar
+java -jar lighty-notifications-device-15.0.0.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-notifications-device-15.0.0-SNAPSHOT.jar 12345
+java -jar lighty-notifications-device-15.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-notifications-device/README.md
+++ b/examples/devices/lighty-notifications-device/README.md
@@ -10,16 +10,16 @@ Check commands in [Notifications device model](#notifications-device-model) on h
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-notifications-device-14.2.0-bin.zip`
+* extract binary distribution `lighty-notifications-device-14.2.1-SNAPSHOT-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-notifications-device-14.2.0.jar
+java -jar lighty-notifications-device-14.2.1-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-notifications-device-14.2.0.jar 12345
+java -jar lighty-notifications-device-14.2.1-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-notifications-device/pom.xml
+++ b/examples/devices/lighty-notifications-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>15.0.0-SNAPSHOT</version>
+        <version>15.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-notifications-device/pom.xml
+++ b/examples/devices/lighty-notifications-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.2.1-SNAPSHOT</version>
+        <version>15.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-notifications-device-14.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-notifications-device-15.0.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-notifications-device-15.0.0-SNAPSHOT.jar
+CLASSPATH=lighty-notifications-device-15.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-notifications-device-14.2.0.jar
+CLASSPATH=lighty-notifications-device-14.2.1-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-notifications-device/src/main/java/io/lighty/netconf/device/notification/processors/TriggerNotificationProcessor.java
+++ b/examples/devices/lighty-notifications-device/src/main/java/io/lighty/netconf/device/notification/processors/TriggerNotificationProcessor.java
@@ -61,7 +61,7 @@ public class TriggerNotificationProcessor extends RpcOutputRequestProcessor {
         try {
             final XmlNodeConverter xmlNodeConverter = getNetconfDeviceServices().getXmlNodeConverter();
             try (Reader readerFromElement = RPCUtil.createReaderFromElement(requestXmlElement)) {
-                final NormalizedNode<?, ?> deserializedNode =
+                final NormalizedNode deserializedNode =
                         xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
                 final TriggerDataNotificationInput input = this.dataCodec
                         .convertToBindingAwareRpc(getRpcDefinition().getInput().getPath().asAbsolute(),

--- a/examples/devices/lighty-toaster-device/README.md
+++ b/examples/devices/lighty-toaster-device/README.md
@@ -13,16 +13,16 @@ of the processor calls method of `ToasterServiceImpl` which implements
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-toaster-device-14.2.1-SNAPSHOT-bin.zip`
+* extract binary distribution `lighty-toaster-device-15.0.0-SNAPSHOT-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-toaster-device-14.2.1-SNAPSHOT.jar
+java -jar lighty-toaster-device-15.0.0-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-toaster-device-14.2.1-SNAPSHOT.jar 12345
+java -jar lighty-toaster-device-15.0.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-device/README.md
+++ b/examples/devices/lighty-toaster-device/README.md
@@ -13,16 +13,16 @@ of the processor calls method of `ToasterServiceImpl` which implements
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-toaster-device-15.0.0-SNAPSHOT-bin.zip`
+* extract binary distribution `lighty-toaster-device-15.0.0-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-toaster-device-15.0.0-SNAPSHOT.jar
+java -jar lighty-toaster-device-15.0.0.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-toaster-device-15.0.0-SNAPSHOT.jar 12345
+java -jar lighty-toaster-device-15.0.0.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-device/README.md
+++ b/examples/devices/lighty-toaster-device/README.md
@@ -13,16 +13,16 @@ of the processor calls method of `ToasterServiceImpl` which implements
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-toaster-device-14.2.0-bin.zip`
+* extract binary distribution `lighty-toaster-device-14.2.1-SNAPSHOT-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-toaster-device-14.2.0.jar
+java -jar lighty-toaster-device-14.2.1-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-toaster-device-14.2.0.jar 12345
+java -jar lighty-toaster-device-14.2.1-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-device/pom.xml
+++ b/examples/devices/lighty-toaster-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>15.0.0-SNAPSHOT</version>
+        <version>15.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-device/pom.xml
+++ b/examples/devices/lighty-toaster-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.2.1-SNAPSHOT</version>
+        <version>15.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-toaster-device-15.0.0-SNAPSHOT.jar
+CLASSPATH=lighty-toaster-device-15.0.0.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-toaster-device-14.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-toaster-device-15.0.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-toaster-device-14.2.0.jar
+CLASSPATH=lighty-toaster-device-14.2.1-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
+++ b/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
@@ -7,9 +7,8 @@
  */
 package io.lighty.netconf.device.toaster.processors;
 
-import io.lighty.codecs.DataCodec;
-import io.lighty.codecs.XmlNodeConverter;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
+import io.lighty.codecs.util.XmlNodeConverter;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.requests.RpcOutputRequestProcessor;
 import io.lighty.netconf.device.response.Response;
@@ -25,10 +24,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.xml.transform.TransformerException;
+import org.opendaylight.mdsal.binding.dom.adapter.ConstantAdapterContext;
+import org.opendaylight.mdsal.binding.dom.adapter.CurrentAdapterSerializer;
 import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.common.RpcResult;
 import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier.Absolute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -37,12 +39,14 @@ public abstract class ToasterServiceAbstractProcessor<I extends DataObject, O ex
         RpcOutputRequestProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(ToasterServiceAbstractProcessor.class);
-    private DataCodec<I> dataCodec;
+    private CurrentAdapterSerializer adapterSerializer;
 
     @Override
     public void init(final NetconfDeviceServices netconfDeviceServices) {
         super.init(netconfDeviceServices);
-        this.dataCodec = new DataCodec<>(netconfDeviceServices.getAdapterContext().currentSerializer());
+        final ConstantAdapterContext constantAdapterContext
+                = new ConstantAdapterContext(netconfDeviceServices.getAdapterContext().currentSerializer());
+        this.adapterSerializer = constantAdapterContext.currentSerializer();
     }
 
     @Override
@@ -55,15 +59,15 @@ public abstract class ToasterServiceAbstractProcessor<I extends DataObject, O ex
                     xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
 
             //2. convert NormalizedNode into RPC input
-            final I input = this.dataCodec.convertToBindingAwareRpc(
-                    getRpcDefinition().getInput().getPath().asAbsolute(), (ContainerNode) deserializedNode);
+            final I input = convertToBindingAwareRpc(getRpcDefinition().getInput().getPath().asAbsolute(),
+                    (ContainerNode) deserializedNode);
 
             //3. invoke RPC and wait for completion
             final Future<RpcResult<O>> invokeRpc = execMethod(input);
             final RpcResult<O> rpcResult = invokeRpc.get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
             //4. convert RPC output to ContainerNode
-            final ContainerNode data = this.dataCodec.convertToBindingIndependentRpc(rpcResult.getResult());
+            final ContainerNode data = this.adapterSerializer.toNormalizedNodeRpcData(rpcResult.getResult());
 
             //5. create response
             return CompletableFuture.completedFuture(new ResponseData(Collections.singletonList(data)));
@@ -80,4 +84,8 @@ public abstract class ToasterServiceAbstractProcessor<I extends DataObject, O ex
 
     protected abstract Future<RpcResult<O>> execMethod(I input);
 
+    @SuppressWarnings("unchecked")
+    public I convertToBindingAwareRpc(final Absolute absolute, final ContainerNode rpcData) {
+        return (I) this.adapterSerializer.fromNormalizedNodeRpcData(absolute, rpcData);
+    }
 }

--- a/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
+++ b/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/processors/ToasterServiceAbstractProcessor.java
@@ -47,14 +47,14 @@ public abstract class ToasterServiceAbstractProcessor<I extends DataObject, O ex
 
     @Override
     protected CompletableFuture<Response> execute(final Element requestXmlElement) {
-        //1. convert XML input into NormalizedNode<?, ?>
+        //1. convert XML input into NormalizedNode
         try (Reader readerFromElement = RPCUtil.createReaderFromElement(requestXmlElement);) {
             final XmlNodeConverter xmlNodeConverter = getNetconfDeviceServices().getXmlNodeConverter();
 
-            final NormalizedNode<?, ?> deserializedNode =
+            final NormalizedNode deserializedNode =
                     xmlNodeConverter.deserialize(getRpcDefinition().getInput(), readerFromElement);
 
-            //2. convert NormalizedNode<?, ?> into RPC input
+            //2. convert NormalizedNode into RPC input
             final I input = this.dataCodec.convertToBindingAwareRpc(
                     getRpcDefinition().getInput().getPath().asAbsolute(), (ContainerNode) deserializedNode);
 

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.lighty.codecs.xml.XmlUtil;
 import io.lighty.netconf.device.utils.TimeoutUtil;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -33,6 +32,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendaylight.netconf.api.NetconfMessage;
+import org.opendaylight.netconf.api.xml.XmlUtil;
 import org.opendaylight.netconf.client.NetconfClientDispatcher;
 import org.opendaylight.netconf.client.NetconfClientDispatcherImpl;
 import org.opendaylight.netconf.client.NetconfClientSession;

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -13,7 +13,7 @@ Build root project - for more details check: [README](../../../README.md)
 `--starting-port STARTING-PORT` (Default 17380) First port for simulated device. Each other device will use incremented port number.    
 `--thread-pool-size THREAD-POOL-SIZE` (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.    
 ```
-java -jar lighty-toaster-multiple-devices-15.0.0-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
+java -jar lighty-toaster-multiple-devices-15.0.0.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -13,7 +13,7 @@ Build root project - for more details check: [README](../../../README.md)
 `--starting-port STARTING-PORT` (Default 17380) First port for simulated device. Each other device will use incremented port number.    
 `--thread-pool-size THREAD-POOL-SIZE` (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.    
 ```
-java -jar lighty-toaster-multiple-devices-14.2.0.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
+java -jar lighty-toaster-multiple-devices-14.2.1-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -13,7 +13,7 @@ Build root project - for more details check: [README](../../../README.md)
 `--starting-port STARTING-PORT` (Default 17380) First port for simulated device. Each other device will use incremented port number.    
 `--thread-pool-size THREAD-POOL-SIZE` (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.    
 ```
-java -jar lighty-toaster-multiple-devices-14.2.1-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
+java -jar lighty-toaster-multiple-devices-15.0.0-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>15.0.0-SNAPSHOT</version>
+        <version>15.0.0</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>14.2.1-SNAPSHOT</version>
+        <version>15.0.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
@@ -15,7 +15,7 @@
 # ./start-device --starting-port 20000 --device-count 200 --thread-pool-size 200
 #
 
-CLASSPATH=lighty-toaster-multiple-devices-15.0.0-SNAPSHOT.jar
+CLASSPATH=lighty-toaster-multiple-devices-15.0.0.jar
 
 ARGUMENT_LIST=(
     "device-count"

--- a/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
@@ -15,7 +15,7 @@
 # ./start-device --starting-port 20000 --device-count 200 --thread-pool-size 200
 #
 
-CLASSPATH=lighty-toaster-multiple-devices-14.2.0.jar
+CLASSPATH=lighty-toaster-multiple-devices-14.2.1-SNAPSHOT.jar
 
 ARGUMENT_LIST=(
     "device-count"

--- a/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
@@ -15,7 +15,7 @@
 # ./start-device --starting-port 20000 --device-count 200 --thread-pool-size 200
 #
 
-CLASSPATH=lighty-toaster-multiple-devices-14.2.1-SNAPSHOT.jar
+CLASSPATH=lighty-toaster-multiple-devices-15.0.0-SNAPSHOT.jar
 
 ARGUMENT_LIST=(
     "device-count"

--- a/examples/devices/pom.xml
+++ b/examples/devices/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>devices-aggregator</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/devices/pom.xml
+++ b/examples/devices/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>devices-aggregator</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>14.2.1</version>
+        <version>15.0.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -18,5 +18,5 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-data-center-model</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
 </project>

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -18,5 +18,5 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-data-center-model</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
 </project>

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-network-topology-device-model</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-network-topology-device-model</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
 
     <dependencies>
         <dependency>

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>14.2.1</version>
+        <version>15.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -17,6 +17,6 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-notifications-model</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
 
 </project>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -17,6 +17,6 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-notifications-model</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
 
 </project>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>14.2.1</version>
+        <version>15.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/models/pom.xml
+++ b/examples/models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/models/pom.xml
+++ b/examples/models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-bom</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,42 +26,42 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-network-topology-device-model</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-data-center-model</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device</groupId>
                 <artifactId>lighty-netconf-device</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-actions-device</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-device</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-network-topology-device</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-multiple-devices</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-notifications-model</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-bom</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,42 +26,42 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-network-topology-device-model</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-data-center-model</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device</groupId>
                 <artifactId>lighty-netconf-device</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-actions-device</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-device</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-network-topology-device</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-multiple-devices</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-notifications-model</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
             </dependency>
 
             <dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>examples-bom</artifactId>
-                <version>15.0.0-SNAPSHOT</version>
+                <version>15.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>examples-bom</artifactId>
-                <version>14.2.1-SNAPSHOT</version>
+                <version>15.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>14.2.1</version>
+        <version>15.0.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/parents/pom.xml
+++ b/examples/parents/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.netconf.device.examples.parents</groupId>
     <artifactId>parents-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
 
     <modules>
         <module>examples-parent</module>

--- a/examples/parents/pom.xml
+++ b/examples/parents/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.netconf.device.examples.parents</groupId>
     <artifactId>parents-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
 
     <modules>
         <module>examples-parent</module>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
 
     <modules>
         <module>parents</module>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
 
     <modules>
         <module>parents</module>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>lighty-netconf-device</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>lighty-netconf-device</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.core</groupId>
-            <artifactId>lighty-codecs</artifactId>
+            <artifactId>lighty-codecs-util</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>14.2.1</version>
+        <version>15.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device</groupId>

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
@@ -8,7 +8,7 @@
 package io.lighty.netconf.device;
 
 import com.google.common.util.concurrent.FluentFuture;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.requests.RequestProcessor;
 import io.lighty.netconf.device.requests.RpcHandlerImpl;
 import io.lighty.netconf.device.requests.notification.NotificationPublishServiceImpl;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
@@ -108,7 +108,7 @@ public class NetconfDeviceImpl implements NetconfDevice {
     private void initDatastore(LogicalDatastoreType datastoreType, InputStream initialData) {
         LOG.debug("Setting up initial state of {} datastore from XML", datastoreType);
         try (Reader reader = new InputStreamReader(initialData, Charset.defaultCharset())) {
-            NormalizedNode<?, ?> initialDataBI = netconfDeviceServices.getXmlNodeConverter()
+            NormalizedNode initialDataBI = netconfDeviceServices.getXmlNodeConverter()
                     .deserialize(netconfDeviceServices.getRootSchemaNode(), reader);
             DOMDataTreeWriteTransaction writeTx = netconfDeviceServices.getDOMDataBroker().newWriteOnlyTransaction();
             writeTx.put(datastoreType, YangInstanceIdentifier.empty(), initialDataBI);

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceServices.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceServices.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.netconf.device;
 
-import io.lighty.codecs.XmlNodeConverter;
+import io.lighty.codecs.util.XmlNodeConverter;
 import io.lighty.netconf.device.requests.notification.NotificationPublishService;
 import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.NotificationService;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceServicesImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceServicesImpl.java
@@ -42,8 +42,8 @@ import org.opendaylight.yangtools.yang.data.util.DataSchemaContextTree;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContextListener;
 import org.opendaylight.yangtools.yang.model.api.SchemaNode;
-import org.opendaylight.yangtools.yang.parser.impl.YangParserFactoryImpl;
-import org.opendaylight.yangtools.yang.xpath.impl.AntlrXPathParserFactory;
+import org.opendaylight.yangtools.yang.parser.api.YangParserFactory;
+import org.opendaylight.yangtools.yang.parser.impl.DefaultYangParserFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +153,7 @@ public class NetconfDeviceServicesImpl implements NetconfDeviceServices {
     }
 
     private AdapterContext createAdapterContext(Collection<YangModuleInfo> moduleInfos) {
-        final YangParserFactoryImpl yangParserFactory = new YangParserFactoryImpl(new AntlrXPathParserFactory());
+        final YangParserFactory yangParserFactory = new DefaultYangParserFactory();
         ModuleInfoSnapshotResolver snapshotResolver
                 = new ModuleInfoSnapshotResolver("netconf-simulator", yangParserFactory);
         snapshotResolver.registerModuleInfos(moduleInfos);

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceServicesImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceServicesImpl.java
@@ -10,7 +10,7 @@ package io.lighty.netconf.device;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.lighty.codecs.XmlNodeConverter;
+import io.lighty.codecs.util.XmlNodeConverter;
 import io.lighty.netconf.device.requests.notification.NotificationPublishService;
 import io.lighty.netconf.device.requests.notification.NotificationPublishServiceImpl;
 import java.util.Collection;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.netconf.device.requests;
 
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.response.Response;
 import io.lighty.netconf.device.utils.TimeoutUtil;
@@ -178,6 +178,6 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
     }
 
     protected abstract String convertNormalizedNodeToXmlString(NormalizedNode normalizedNode)
-            throws SerializationException;
+            throws SerializationException, SerializationException;
 
 }

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
@@ -113,7 +113,7 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
         }
     }
 
-    protected abstract Document wrapToFinalDocumentReply(List<NormalizedNode<?, ?>> responseOutput)
+    protected abstract Document wrapToFinalDocumentReply(List<NormalizedNode> responseOutput)
         throws ParserConfigurationException;
 
     /**
@@ -126,7 +126,7 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
      * @param document       a document
      * @return Node the output node
      */
-    protected List<Node> convertOutputToXmlNodes(List<NormalizedNode<?, ?>> responseOutput, DocumentBuilder builder,
+    protected List<Node> convertOutputToXmlNodes(List<NormalizedNode> responseOutput, DocumentBuilder builder,
                                                  Document document) {
         Node responseOutputAsXmlNode;
         if (responseOutput.isEmpty()) {
@@ -148,9 +148,9 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
         return nodes;
     }
 
-    private List<String> convertOutputNormalizedNodesToXmlStrings(List<NormalizedNode<?, ?>> responseOutput) {
-        List<NormalizedNode<?, ?>> toConvert = new ArrayList<>();
-        for (NormalizedNode<?, ?> normalizedNode : responseOutput) {
+    private List<String> convertOutputNormalizedNodesToXmlStrings(List<NormalizedNode> responseOutput) {
+        List<NormalizedNode> toConvert = new ArrayList<>();
+        for (NormalizedNode normalizedNode : responseOutput) {
             // in case of MapNode we need to wrap every MapEntryNode to MapNode and serialize separately
             if (normalizedNode instanceof MapNode) {
                 toConvert.addAll(((MapNode) normalizedNode).getValue().stream().map(mapEntryNode ->
@@ -165,7 +165,7 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
             }
         }
         List<String> converted = new ArrayList<>();
-        for (NormalizedNode<?, ?> node : toConvert) {
+        for (NormalizedNode node : toConvert) {
             try {
                 converted.add(convertNormalizedNodeToXmlString(node));
             } catch (SerializationException e) {
@@ -177,7 +177,7 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
         return converted;
     }
 
-    protected abstract String convertNormalizedNodeToXmlString(NormalizedNode<?, ?> normalizedNode)
+    protected abstract String convertNormalizedNodeToXmlString(NormalizedNode normalizedNode)
             throws SerializationException;
 
 }

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/BaseRequestProcessor.java
@@ -153,10 +153,11 @@ public abstract class BaseRequestProcessor implements RequestProcessor {
         for (NormalizedNode normalizedNode : responseOutput) {
             // in case of MapNode we need to wrap every MapEntryNode to MapNode and serialize separately
             if (normalizedNode instanceof MapNode) {
-                toConvert.addAll(((MapNode) normalizedNode).getValue().stream().map(mapEntryNode ->
+                toConvert.addAll(((MapNode) normalizedNode).body().stream().map(mapEntryNode ->
                         ImmutableMapNodeBuilder.create()
                                 .withNodeIdentifier(
-                                        YangInstanceIdentifier.NodeIdentifier.create(normalizedNode.getNodeType()))
+                                        YangInstanceIdentifier.NodeIdentifier.create(normalizedNode.getIdentifier()
+                                                .getNodeType()))
                                 .withChild(mapEntryNode)
                                 .build())
                         .collect(Collectors.toList()));

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
@@ -37,17 +37,17 @@ public abstract class DatastoreOutputRequestProcessor extends BaseRequestProcess
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreOutputRequestProcessor.class);
 
     @Override
-    protected String convertNormalizedNodeToXmlString(NormalizedNode<?, ?> normalizedNode)
+    protected String convertNormalizedNodeToXmlString(NormalizedNode normalizedNode)
             throws SerializationException {
         return getNetconfDeviceServices().getXmlNodeConverter()
                 .serializeData(getNetconfDeviceServices().getRootSchemaNode(), normalizedNode).toString();
     }
 
-    protected List<NormalizedNode<?, ?>> getAllDataFromDatastore(LogicalDatastoreType datastoreType) {
+    protected List<NormalizedNode> getAllDataFromDatastore(LogicalDatastoreType datastoreType) {
         DOMDataBroker domDataBroker = getNetconfDeviceServices().getDOMDataBroker();
-        Optional<NormalizedNode<?, ?>> listData;
+        Optional<NormalizedNode> listData;
         try (DOMDataTreeReadTransaction domDataReadOnlyTransaction = domDataBroker.newReadOnlyTransaction()) {
-            FluentFuture<Optional<NormalizedNode<?, ?>>> readData =
+            FluentFuture<Optional<NormalizedNode>> readData =
                     domDataReadOnlyTransaction.read(datastoreType, YangInstanceIdentifier.empty());
             listData = readData.get(TimeoutUtil.TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
@@ -65,7 +65,7 @@ public abstract class DatastoreOutputRequestProcessor extends BaseRequestProcess
     }
 
     @Override
-    protected Document wrapToFinalDocumentReply(List<NormalizedNode<?, ?>> responseOutput)
+    protected Document wrapToFinalDocumentReply(List<NormalizedNode> responseOutput)
             throws ParserConfigurationException {
         // convert normalized nodes to xml nodes
         DocumentBuilder builder = getDocumentBuilderFactory().newDocumentBuilder();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
@@ -8,7 +8,7 @@
 package io.lighty.netconf.device.requests;
 
 import com.google.common.util.concurrent.FluentFuture;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.utils.RPCUtil;
 import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.util.ArrayList;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DatastoreOutputRequestProcessor.java
@@ -53,7 +53,7 @@ public abstract class DatastoreOutputRequestProcessor extends BaseRequestProcess
 
             if (listData.isPresent()) {
                 ContainerNode containerNode = (ContainerNode) listData.get();
-                return new ArrayList<>(containerNode.getValue());
+                return new ArrayList<>(containerNode.body());
             }
         } catch (ExecutionException | TimeoutException e) {
             LOG.error("Exception thrown while getting data from datastore!", e);

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DeleteConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/DeleteConfigRequestProcessor.java
@@ -10,10 +10,10 @@ package io.lighty.netconf.device.requests;
 import io.lighty.netconf.device.response.Response;
 import io.lighty.netconf.device.utils.RPCUtil;
 import java.util.concurrent.CompletableFuture;
-import org.opendaylight.netconf.api.DocumentedException.ErrorSeverity;
-import org.opendaylight.netconf.api.DocumentedException.ErrorTag;
-import org.opendaylight.netconf.api.DocumentedException.ErrorType;
 import org.opendaylight.netconf.api.NetconfDocumentedException;
+import org.opendaylight.yangtools.yang.common.ErrorSeverity;
+import org.opendaylight.yangtools.yang.common.ErrorTag;
+import org.opendaylight.yangtools.yang.common.ErrorType;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.w3c.dom.Element;
 

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.response.Response;
 import io.lighty.netconf.device.response.ResponseData;
 import io.lighty.netconf.device.response.ResponseErrorMessage;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
@@ -41,11 +41,11 @@ import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
 import org.opendaylight.mdsal.common.api.TransactionCommitFailedException;
 import org.opendaylight.mdsal.dom.api.DOMDataTreeReadTransaction;
 import org.opendaylight.mdsal.dom.api.DOMDataTreeWriteTransaction;
-import org.opendaylight.netconf.api.DocumentedException.ErrorSeverity;
-import org.opendaylight.netconf.api.DocumentedException.ErrorTag;
-import org.opendaylight.netconf.api.DocumentedException.ErrorType;
 import org.opendaylight.netconf.api.NetconfDocumentedException;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.netconf.base._1._0.rev110601.copy.config.input.source.config.source.Config;
+import org.opendaylight.yangtools.yang.common.ErrorSeverity;
+import org.opendaylight.yangtools.yang.common.ErrorTag;
+import org.opendaylight.yangtools.yang.common.ErrorType;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.PathArgument;
@@ -126,7 +126,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
         NormalizedNode data;
         if (path == null) {
             Optional<DataContainerChild> optionalData =
-                ((AbstractCollection<DataContainerChild>) configNN.getValue()).stream().findFirst();
+                ((AbstractCollection<DataContainerChild>) configNN.body()).stream().findFirst();
             if (optionalData.isEmpty()) {
                 return CompletableFuture.completedFuture(new ResponseErrorMessage(
                     new NetconfDocumentedException(
@@ -136,7 +136,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
                         ErrorSeverity.ERROR)));
             }
             data = optionalData.get();
-            path = YangInstanceIdentifier.builder().node(data.getNodeType()).build();
+            path = YangInstanceIdentifier.builder().node(data.getIdentifier().getNodeType()).build();
         } else {
             Optional<NormalizedNode> optionalData =
                 NormalizedNodes.findNode(configNN, path);
@@ -309,7 +309,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
             final Optional<NormalizedNode> findNode =
                     NormalizedNodes.findNode(input, targetIdentifier.getPathArguments());
             if (contextNode.isKeyedEntry() && findNode.isPresent()) {
-                final MapEntryNode next = ((MapNode) findNode.get()).getValue().iterator().next();
+                final MapEntryNode next = ((MapNode) findNode.get()).body().iterator().next();
                 final Map<QName, Object> keyValues = next.getIdentifier().asMap();
                 targetIdentifier = YangInstanceIdentifier
                         .builder(YangInstanceIdentifier.create(targetIdentifier.getPathArguments()))

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/EditConfigRequestProcessor.java
@@ -106,7 +106,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
 
         final String configString = RPCUtil.formatXml(configElement);
 
-        NormalizedNode<?, ?> configNN;
+        NormalizedNode configNN;
         try {
             configNN = getNetconfDeviceServices().getXmlNodeConverter()
                     .deserialize(getNetconfDeviceServices().getRootSchemaNode(), new StringReader(configString));
@@ -123,10 +123,10 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
                 .currentSerializer().getRuntimeContext().getEffectiveModelContext();
         YangInstanceIdentifier path = retrieveElementYII(effectiveModelContext, configNN,
                 configElement, "//*[@*[local-name() = 'operation']]");
-        NormalizedNode<?, ?> data;
+        NormalizedNode data;
         if (path == null) {
-            Optional<DataContainerChild<?, ?>> optionalData =
-                ((AbstractCollection<DataContainerChild<?, ?>>) configNN.getValue()).stream().findFirst();
+            Optional<DataContainerChild> optionalData =
+                ((AbstractCollection<DataContainerChild>) configNN.getValue()).stream().findFirst();
             if (optionalData.isEmpty()) {
                 return CompletableFuture.completedFuture(new ResponseErrorMessage(
                     new NetconfDocumentedException(
@@ -138,7 +138,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
             data = optionalData.get();
             path = YangInstanceIdentifier.builder().node(data.getNodeType()).build();
         } else {
-            Optional<NormalizedNode<?, ?>> optionalData =
+            Optional<NormalizedNode> optionalData =
                 NormalizedNodes.findNode(configNN, path);
             if (optionalData.isEmpty()) {
                 return CompletableFuture.completedFuture(new ResponseErrorMessage(
@@ -231,13 +231,13 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
 
         Preconditions.checkArgument(rootNormalizedPath != null, "Empty path received");
 
-        final NormalizedNode<?, ?> parentStructure = ImmutableNodes.fromInstanceId(effectiveModelContext,
+        final NormalizedNode parentStructure = ImmutableNodes.fromInstanceId(effectiveModelContext,
                 YangInstanceIdentifier.create(normalizedPathWithoutChildArgs));
         writeTx.merge(LogicalDatastoreType.CONFIGURATION, rootNormalizedPath, parentStructure);
     }
 
     private IllegalStateException createTxException(
-        final NormalizedNode<?, ?> data, final Exception exception, final String type) {
+        final NormalizedNode data, final Exception exception, final String type) {
         return new IllegalStateException("Unable to execute " + type + " operation with data:\n"
             + NormalizedNodes.toStringTree(data), exception);
     }
@@ -262,7 +262,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
     }
 
     protected static YangInstanceIdentifier retrieveElementYII(
-            final EffectiveModelContext effectiveModelContext, final NormalizedNode<?, ?> normalizedNode,
+            final EffectiveModelContext effectiveModelContext, final NormalizedNode normalizedNode,
             final Element deviceElement, final String xpathExpression) {
         final List<Node> nodes = RPCUtil.getNodes(deviceElement.getChildNodes());
         if (nodes.isEmpty()) {
@@ -292,7 +292,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
      * @return YangInstanceIdentifier a yang instance identifier
      */
     private static YangInstanceIdentifier getYangInstanceIdentifier(final List<QName> yangPath,
-            final NormalizedNode<?, ?> input, final EffectiveModelContext effectiveModelContext) {
+            final NormalizedNode input, final EffectiveModelContext effectiveModelContext) {
         DataSchemaContextNode<?> contextNode = DataSchemaContextTree.from(effectiveModelContext).getRoot();
         YangInstanceIdentifier targetIdentifier = YangInstanceIdentifier.builder().build();
         final Iterator<QName> iterator = yangPath.iterator();
@@ -306,7 +306,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
                 contextNode = requireNonNull(contextNode.getChild(currentQname));
             }
 
-            final Optional<NormalizedNode<?, ?>> findNode =
+            final Optional<NormalizedNode> findNode =
                     NormalizedNodes.findNode(input, targetIdentifier.getPathArguments());
             if (contextNode.isKeyedEntry() && findNode.isPresent()) {
                 final MapEntryNode next = ((MapNode) findNode.get()).getValue().iterator().next();
@@ -350,7 +350,7 @@ public class EditConfigRequestProcessor extends OkOutputRequestProcessor {
     }
 
     private boolean dataExists(final YangInstanceIdentifier path, final Operation operationToExecute,
-            final NormalizedNode<?, ?> data) {
+            final NormalizedNode data) {
         try (DOMDataTreeReadTransaction readTx =
                      getNetconfDeviceServices().getDOMDataBroker().newReadOnlyTransaction()) {
             return readTx.exists(LogicalDatastoreType.CONFIGURATION, path)

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/GetConfigRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/GetConfigRequestProcessor.java
@@ -33,7 +33,7 @@ public class GetConfigRequestProcessor extends DatastoreOutputRequestProcessor {
     @Override
     public CompletableFuture<Response> execute(Element requestXml) {
         final CompletableFuture<Response> responseFuture = new CompletableFuture<>();
-        final List<NormalizedNode<?, ?>> allDataFromDatastore =
+        final List<NormalizedNode> allDataFromDatastore =
                 getAllDataFromDatastore(LogicalDatastoreType.CONFIGURATION);
         responseFuture.complete(new ResponseData(allDataFromDatastore));
         return responseFuture;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/GetRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/GetRequestProcessor.java
@@ -33,7 +33,7 @@ public class GetRequestProcessor extends DatastoreOutputRequestProcessor {
     @Override
     public CompletableFuture<Response> execute(Element requestXml) {
         final CompletableFuture<Response> responseFuture = new CompletableFuture<>();
-        final List<NormalizedNode<?, ?>> allDataFromDatastore =
+        final List<NormalizedNode> allDataFromDatastore =
                 getAllDataFromDatastore(LogicalDatastoreType.OPERATIONAL);
         responseFuture.complete(new ResponseData(allDataFromDatastore));
         return  responseFuture;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/OkOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/OkOutputRequestProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.netconf.device.requests;
 
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.response.Response;
 import io.lighty.netconf.device.utils.RPCUtil;
 import java.util.ArrayList;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/OkOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/OkOutputRequestProcessor.java
@@ -35,19 +35,19 @@ public abstract class OkOutputRequestProcessor extends BaseRequestProcessor {
     protected abstract CompletableFuture<Response> executeOkRequest(Element requestXmlElement);
 
     @Override
-    protected List<Node> convertOutputToXmlNodes(List<NormalizedNode<?, ?>> responseOutput, DocumentBuilder builder,
+    protected List<Node> convertOutputToXmlNodes(List<NormalizedNode> responseOutput, DocumentBuilder builder,
             Document document) {
         return Collections.singletonList(RPCUtil.createOkNode(document));
     }
 
     @Override
-    protected String convertNormalizedNodeToXmlString(NormalizedNode<?, ?> normalizedNode)
+    protected String convertNormalizedNodeToXmlString(NormalizedNode normalizedNode)
             throws SerializationException {
         throw new IllegalStateException("This method should not be called!");
     }
 
     @Override
-    protected Document wrapToFinalDocumentReply(List<NormalizedNode<?, ?>> responseOutput)
+    protected Document wrapToFinalDocumentReply(List<NormalizedNode> responseOutput)
             throws ParserConfigurationException {
         // convert normalized nodes to xml nodes
         DocumentBuilder builder = getDocumentBuilderFactory().newDocumentBuilder();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
@@ -48,7 +48,7 @@ public abstract class RpcOutputRequestProcessor extends BaseRequestProcessor {
     }
 
     @Override
-    protected String convertNormalizedNodeToXmlString(NormalizedNode<?, ?> normalizedNode)
+    protected String convertNormalizedNodeToXmlString(NormalizedNode normalizedNode)
             throws SerializationException {
         return getNetconfDeviceServices().getXmlNodeConverter()
                 .serializeRpc(rpcDefinition.getOutput(), normalizedNode).toString();
@@ -59,7 +59,7 @@ public abstract class RpcOutputRequestProcessor extends BaseRequestProcessor {
     }
 
     @Override
-    protected Document wrapToFinalDocumentReply(List<NormalizedNode<?, ?>> responseOutput)
+    protected Document wrapToFinalDocumentReply(List<NormalizedNode> responseOutput)
         throws ParserConfigurationException {
         DocumentBuilder builder = getDocumentBuilderFactory().newDocumentBuilder();
         Document newDocument = builder.newDocument();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
@@ -7,8 +7,8 @@
  */
 package io.lighty.netconf.device.requests;
 
-import io.lighty.codecs.api.ConverterUtils;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.ConverterUtils;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.utils.RPCUtil;
 import java.util.ArrayList;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/RpcOutputRequestProcessor.java
@@ -18,8 +18,8 @@ import java.util.Optional;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
-import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -36,7 +36,7 @@ public abstract class RpcOutputRequestProcessor extends BaseRequestProcessor {
     @Override
     public void init(NetconfDeviceServices netconfDeviceServices) {
         super.init(netconfDeviceServices);
-        SchemaContext schemaContext = getNetconfDeviceServices().getAdapterContext().currentSerializer()
+        EffectiveModelContext schemaContext = getNetconfDeviceServices().getAdapterContext().currentSerializer()
                 .getRuntimeContext().getEffectiveModelContext();
         Optional<? extends RpcDefinition> rpcDefinitionOptional =
             ConverterUtils.loadRpc(schemaContext, getIdentifier());

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/CreateSubscriptionRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/CreateSubscriptionRequestProcessor.java
@@ -51,7 +51,7 @@ public class CreateSubscriptionRequestProcessor extends BaseRequestProcessor {
     @SuppressWarnings("checkstyle:AvoidHidingCauseException")
     @Override
     protected Document wrapToFinalDocumentReply(
-        List<NormalizedNode<?, ?>> responseOutput) throws ParserConfigurationException {
+        List<NormalizedNode> responseOutput) throws ParserConfigurationException {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
@@ -77,7 +77,7 @@ public class CreateSubscriptionRequestProcessor extends BaseRequestProcessor {
     }
 
     @Override
-    protected String convertNormalizedNodeToXmlString(NormalizedNode<?, ?> normalizedNode)
+    protected String convertNormalizedNodeToXmlString(NormalizedNode normalizedNode)
         throws SerializationException {
         throw new IllegalStateException("This method should not be called!");
     }

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/CreateSubscriptionRequestProcessor.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/CreateSubscriptionRequestProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.netconf.device.requests.notification;
 
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.SerializationException;
 import io.lighty.netconf.device.requests.BaseRequestProcessor;
 import io.lighty.netconf.device.response.Response;
 import io.lighty.netconf.device.response.ResponseData;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/NotificationOperation.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/requests/notification/NotificationOperation.java
@@ -7,9 +7,9 @@
  */
 package io.lighty.netconf.device.requests.notification;
 
-import io.lighty.codecs.XmlNodeConverter;
-import io.lighty.codecs.api.ConverterUtils;
-import io.lighty.codecs.api.SerializationException;
+import io.lighty.codecs.util.ConverterUtils;
+import io.lighty.codecs.util.SerializationException;
+import io.lighty.codecs.util.XmlNodeConverter;
 import io.lighty.netconf.device.utils.RPCUtil;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/response/Response.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/response/Response.java
@@ -18,7 +18,7 @@ public interface Response {
      *
      * @return data
      */
-    List<NormalizedNode<? ,?>> getData();
+    List<NormalizedNode> getData();
 
     /**
      * Specific Error returned according to unsuccessful requests.

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/response/ResponseData.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/response/ResponseData.java
@@ -13,14 +13,14 @@ import org.w3c.dom.Document;
 
 public class ResponseData implements Response {
 
-    private final List<NormalizedNode<?, ?>> data;
+    private final List<NormalizedNode> data;
 
-    public ResponseData(final List<NormalizedNode<?, ?>> data) {
+    public ResponseData(final List<NormalizedNode> data) {
         this.data = data;
     }
 
     @Override
-    public List<NormalizedNode<?, ?>> getData() {
+    public List<NormalizedNode> getData() {
         return data;
     }
 

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/response/ResponseErrorMessage.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/response/ResponseErrorMessage.java
@@ -22,7 +22,7 @@ public class ResponseErrorMessage implements Response {
     }
 
     @Override
-    public List<NormalizedNode<?, ?>> getData() {
+    public List<NormalizedNode> getData() {
         return Collections.emptyList();
     }
 

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
@@ -71,12 +71,10 @@ public final class RPCUtil {
 
     /**
      * Transform {@link Element} instance into {@link Reader}.
-     * @param requestXmlElement
-     *     Input {@link Element} instance.
-     * @return
-     * {@link Reader} instance containing input XML element;
-     * @throws TransformerException
-     *     In case transformation fails;
+     *
+     * @param requestXmlElement Input {@link Element} instance.
+     * @return {@link Reader} instance containing input XML element;
+     * @throws TransformerException In case transformation fails;
      */
     public static Reader createReaderFromElement(Element requestXmlElement) throws TransformerException {
         Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
@@ -87,9 +85,9 @@ public final class RPCUtil {
         return new StringReader(sw.toString());
     }
 
-    public static List<NormalizedNode<?, ?>> createNormalizedNodesForMapNodeEntries(
-        Optional<NormalizedNode<?, ?>> listNormalizedNode) {
-        List<NormalizedNode<?, ?>> normalizedNodes = new ArrayList<>();
+    public static List<NormalizedNode> createNormalizedNodesForMapNodeEntries(
+        Optional<NormalizedNode> listNormalizedNode) {
+        List<NormalizedNode> normalizedNodes = new ArrayList<>();
         if (listNormalizedNode.isEmpty()) {
             return normalizedNodes;
         }
@@ -97,9 +95,9 @@ public final class RPCUtil {
                 (DataContainerChild<? extends YangInstanceIdentifier.PathArgument, ?>) listNormalizedNode.get();
         Iterator iterator = ((Collection) nextToCollection.getValue()).iterator();
         while (iterator.hasNext()) {
-            NormalizedNode<?, ?> fabricListEntry =
-                    (NormalizedNode<?, ?>) iterator.next();
-            NormalizedNode<?, ?> fabricListEntryInsideMapNode = ImmutableMapNodeBuilder.create()
+            NormalizedNode fabricListEntry =
+                    (NormalizedNode) iterator.next();
+            NormalizedNode fabricListEntryInsideMapNode = ImmutableMapNodeBuilder.create()
                     .withNodeIdentifier(YangInstanceIdentifier.NodeIdentifier
                             .create(listNormalizedNode.get().getNodeType()))
                     .withChild((MapEntryNode) fabricListEntry).build();

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/RPCUtil.java
@@ -91,15 +91,14 @@ public final class RPCUtil {
         if (listNormalizedNode.isEmpty()) {
             return normalizedNodes;
         }
-        DataContainerChild<? extends YangInstanceIdentifier.PathArgument, ?> nextToCollection =
-                (DataContainerChild<? extends YangInstanceIdentifier.PathArgument, ?>) listNormalizedNode.get();
-        Iterator iterator = ((Collection) nextToCollection.getValue()).iterator();
+        DataContainerChild nextToCollection = (DataContainerChild) listNormalizedNode.get();
+        Iterator iterator = ((Collection) nextToCollection.body()).iterator();
         while (iterator.hasNext()) {
             NormalizedNode fabricListEntry =
                     (NormalizedNode) iterator.next();
             NormalizedNode fabricListEntryInsideMapNode = ImmutableMapNodeBuilder.create()
                     .withNodeIdentifier(YangInstanceIdentifier.NodeIdentifier
-                            .create(listNormalizedNode.get().getNodeType()))
+                            .create(listNormalizedNode.get().getIdentifier().getNodeType()))
                     .withChild((MapEntryNode) fabricListEntry).build();
             normalizedNodes.add(fabricListEntryInsideMapNode);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>netconf-device-aggregator</artifactId>
-    <version>14.2.1-SNAPSHOT</version>
+    <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>netconf-device-aggregator</artifactId>
-    <version>15.0.0-SNAPSHOT</version>
+    <version>15.0.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Update upstream dependencies to the Phosphorus release versions:
  -  lighty.core 15.0.0
  -  netconf notification 2.0.5
  -  netconf testtool 2.0.5

Release notes:
  - Replace List with Map in TopologyBuilder 
  - Fix NormalizedNode interface changes after bump to Phosphorus 
  - Fix changed access to parseArgs method in upstream 
  - Fix wildcards inside normalize nodes
  - Fix resources versions to 14.2.1-SNAPSHOT
  - Use lighty-codecs-util instead of removed lighty-codecs
  - Change xml factories initialization - Remove vulnerability to XXE attacks
  - Resolve sonarcloud reported bugs
