### PR TITLE
Replace slf4j-log4j12 with slf4j-reload4j

### DIFF
--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -32,14 +32,6 @@
             <artifactId>lighty-example-data-center-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.netconf.device</groupId>
             <artifactId>lighty-netconf-device</artifactId>
         </dependency>

--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -32,14 +32,6 @@
             <artifactId>lighty-example-network-topology-device-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.netconf.device</groupId>
             <artifactId>lighty-netconf-device</artifactId>
         </dependency>

--- a/examples/devices/lighty-notifications-device/pom.xml
+++ b/examples/devices/lighty-notifications-device/pom.xml
@@ -32,14 +32,6 @@
             <artifactId>lighty-example-notifications-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.netconf.device</groupId>
             <artifactId>lighty-netconf-device</artifactId>
         </dependency>

--- a/examples/devices/lighty-toaster-device/pom.xml
+++ b/examples/devices/lighty-toaster-device/pom.xml
@@ -33,14 +33,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.netconf.device</groupId>
             <artifactId>lighty-netconf-device</artifactId>
         </dependency>

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -57,16 +57,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -94,6 +94,17 @@
                 <artifactId>xmlunit-assertj</artifactId>
                 <version>2.7.0</version>
             </dependency>
+            <!--  TODO: Remove org.slf4j dependencies when lighty log4j vulnerability will be resolved in release-->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.35</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.35</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -94,17 +94,6 @@
                 <artifactId>xmlunit-assertj</artifactId>
                 <version>2.7.0</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.25</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -52,5 +52,16 @@
         </dependencies>
     </dependencyManagement>
 
+    <!--  TODO: Remove org.slf4j dependencies when lighty log4j vulnerability will be resolved in release-->
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -38,6 +38,12 @@
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-testtool</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Remove redundant slf4j-log4j12 and logback-classic dependencies.
- Override slf4j-log4j12 dependency pulled from lighty with slf4j-reload4j 