### PR TITLE
Bump Lighty.io to 16.1.1

### DIFF
--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>16.0.0</version>
+        <version>16.1.1</version>
         <relativePath/>
     </parent>
 

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>16.0.0</version>
+        <version>16.1.1</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>16.0.0</version>
+        <version>16.1.1</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>16.0.0</version>
+        <version>16.1.1</version>
         <relativePath/>
     </parent>
 

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>16.0.0</version>
+        <version>16.1.1</version>
     </parent>
 
     <groupId>io.lighty.netconf.device</groupId>


### PR DESCRIPTION
Bump Lighty.io dependency to latest Sulfur SR1 based version 16.1.1.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>