### PR TITLE
Bump Lighty.io to 17.0.0

### DIFF
--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.0</version>
     </parent>
 
     <groupId>io.lighty.netconf.device</groupId>


### PR DESCRIPTION
Use Lighty.io version 17.0.0 for simulator release 17.0.0.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>