### PR TITLE
Fix wrong format when creating schema from module

### DIFF
--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceImpl.java
@@ -35,7 +35,7 @@ import org.opendaylight.netconf.test.tool.NetconfDeviceSimulator;
 import org.opendaylight.netconf.test.tool.config.Configuration;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.Uri;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.rev101004.NetconfState;
-import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.rev101004.SchemaFormat;
+import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.rev101004.Yang;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.rev101004.netconf.state.Schemas;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.rev101004.netconf.state.SchemasBuilder;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.rev101004.netconf.state.schemas.Schema;
@@ -179,7 +179,7 @@ public class NetconfDeviceImpl implements NetconfDevice {
     private Schema createSchemaFromModule(ModuleLike module) {
         return new SchemaBuilder()
             .setNamespace(new Uri(module.getNamespace().toString()))
-            .setFormat(SchemaFormat.VALUE)
+            .setFormat(Yang.VALUE)
             .setIdentifier(module.getName())
             .setVersion(module.getRevision().map(Revision::toString).orElse(""))
             .setLocation(Collections.singleton(new Schema.Location(Schema.Location.Enumeration.NETCONF)))


### PR DESCRIPTION
Setting format as SchemaFormat has caused Lighty not to receive schema models from device properly. The cause was that this condition inside netconf used by Lighty was always true due to not using YANG format:

https://github.com/opendaylight/netconf/blob/798a05a2d099fd66040bf3b10635afaec9b3b7d4/netconf/sal-netconf-connector/src/main/java/org/opendaylight/netconf/sal/connect/netconf/NetconfStateSchemas.java#L279

The device sent SchemaFormat format which caused this method to always return Optional.empty().

JIRA: LIGHTY-97

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 22e087208241204205a84a6cd3fa885713436035)