### PR TITLE
Add breaks when result is found

### DIFF
--- a/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
+++ b/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
@@ -110,6 +110,7 @@ public class ActionDeviceTest {
                     if ("example-data-center".equals(schemaName)
                             && "urn:example:data-center".equals(schemaNameSpace)) {
                         exampleDataCenterSchemaContained = true;
+                        break;
                     }
                 }
             }

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -115,6 +115,7 @@ public class DeviceTest {
                     if ("network-topology".equals(schemaName)
                             && "urn:TBD:params:xml:ns:yang:network-topology".equals(schemaNameSpace)) {
                         networkTopologySchemaContained = true;
+                        break;
                     }
                 }
             }

--- a/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
+++ b/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
@@ -113,6 +113,7 @@ public class NotificationTest {
                     if ("lighty-test-notifications".equals(schemaName)
                             && "yang:lighty:test:notifications".equals(schemaNameSpace)) {
                         notificationSchemaContained = true;
+                        break;
                     }
                 }
             }

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -112,6 +112,7 @@ public class ToasterDeviceTest {
                     if ("toaster".equals(schemaName)
                             && "http://netconfcentral.org/ns/toaster".equals(schemaNameSpace)) {
                         toasterSchemaContained = true;
+                        break;
                     }
                 }
             }

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
@@ -124,6 +124,7 @@ public class DeviceTest {
                     if ("toaster".equals(schemaName)
                             && "http://netconfcentral.org/ns/toaster".equals(schemaNameSpace)) {
                         toasterSchemaContained = true;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Add missing break statements to for loops when we are sure that we have found what we were looking for.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 2cf6fbcdef8105ba018b39504372b4ff2f33827d)