### PR TITLE
Remove hamcrest dependency

### DIFF
--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -75,11 +75,6 @@
                 <version>5.9.2</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>2.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-core</artifactId>
                 <version>2.7.0</version>


### PR DESCRIPTION
This dependency is unused.

JIRA:LIGHTY-214
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit ad2eba6bfd04c89580b3bc8f7c34a0cf3b0b0137)