### PR TITLE
Bump to 17.4.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mvn clean install
 ```
 * The NETCONF Device Library build is located at:
 
-`lighty-netconf-device\target\lighty-netconf-device-17.3.0.jar`
+`lighty-netconf-device\target\lighty-netconf-device-17.4.0-SNAPSHOT.jar`
 
 * The build & run procedures for the example devices are described in each device's README.
 

--- a/examples/devices/lighty-actions-device/README.md
+++ b/examples/devices/lighty-actions-device/README.md
@@ -28,12 +28,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-action-device-17.3.0.jar
+java -jar lighty-action-device-17.4.0-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-action-device-17.3.0.jar 12345
+java -jar lighty-action-device-17.4.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>17.3.0</version>
+        <version>17.4.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-actions-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-action-device-17.3.0.jar
+CLASSPATH=lighty-action-device-17.4.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -19,12 +19,12 @@ Build root project - for more details check: [README](../../../README.md)
 * extract binary distribution in target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-network-topology-device-17.3.0.jar
+java -jar lighty-network-topology-device-17.4.0-SNAPSHOT.jar
 ```
 * to run device on specific port it is necessary to add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-network-topology-device-17.3.0.jar 12345
+java -jar lighty-network-topology-device-17.4.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>17.3.0</version>
+        <version>17.4.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-network-topology-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-network-topology-device-17.3.0.jar
+CLASSPATH=lighty-network-topology-device-17.4.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-notifications-device/README.md
+++ b/examples/devices/lighty-notifications-device/README.md
@@ -10,16 +10,16 @@ Check commands in [Notifications device model](#notifications-device-model) on h
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-notifications-device-17.3.0-bin.zip`
+* extract binary distribution `lighty-notifications-device-17.4.0-SNAPSHOT-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-notifications-device-17.3.0.jar
+java -jar lighty-notifications-device-17.4.0-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-notifications-device-17.3.0.jar 12345
+java -jar lighty-notifications-device-17.4.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-notifications-device/pom.xml
+++ b/examples/devices/lighty-notifications-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>17.3.0</version>
+        <version>17.4.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-notifications-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-notifications-device-17.3.0.jar
+CLASSPATH=lighty-notifications-device-17.4.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-toaster-device/README.md
+++ b/examples/devices/lighty-toaster-device/README.md
@@ -13,16 +13,16 @@ of the processor calls method of `ToasterServiceImpl` which implements
 Build root project - for more details check: [README](../../../README.md)
 
 **Run device**
-* extract binary distribution `lighty-toaster-device-17.3.0-bin.zip`
+* extract binary distribution `lighty-toaster-device-17.4.0-SNAPSHOT-bin.zip`
 from target directory
 * run jar file from zip with default parameter
 ```
-java -jar lighty-toaster-device-17.3.0.jar
+java -jar lighty-toaster-device-17.4.0-SNAPSHOT.jar
 ```
 To run device on specific port, add port number as an argument
 * run device on specific port `12345` (any available port)
 ```
-java -jar lighty-toaster-device-17.3.0.jar 12345
+java -jar lighty-toaster-device-17.4.0-SNAPSHOT.jar 12345
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-device/pom.xml
+++ b/examples/devices/lighty-toaster-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>17.3.0</version>
+        <version>17.4.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-device/src/assembly/resources/start-device.sh
@@ -6,7 +6,7 @@
 #
 # When run without a parameter a default port 17830 will be used.
 
-CLASSPATH=lighty-toaster-device-17.3.0.jar
+CLASSPATH=lighty-toaster-device-17.4.0-SNAPSHOT.jar
 
 for jar in `ls -1 lib/`;
 do

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -13,7 +13,7 @@ Build root project - for more details check: [README](../../../README.md)
 `--starting-port STARTING-PORT` (Default 17380) First port for simulated device. Each other device will use incremented port number.    
 `--thread-pool-size THREAD-POOL-SIZE` (Default 8) The number of threads to keep in the pool, when creating a device simulator, even if they are idle.    
 ```
-java -jar lighty-toaster-multiple-devices-17.3.0.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
+java -jar lighty-toaster-multiple-devices-17.4.0-SNAPSHOT.jar --starting-port 20000 --device-count 200 --thread-pool-size 200
 ```
 
 ### Connect to device via SSH

--- a/examples/devices/lighty-toaster-multiple-devices/pom.xml
+++ b/examples/devices/lighty-toaster-multiple-devices/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.netconf.device.examples</groupId>
         <artifactId>examples-parent</artifactId>
-        <version>17.3.0</version>
+        <version>17.4.0-SNAPSHOT</version>
         <relativePath>../../parents/examples-parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
+++ b/examples/devices/lighty-toaster-multiple-devices/src/assembly/resources/start-device.sh
@@ -15,7 +15,7 @@
 # ./start-device --starting-port 20000 --device-count 200 --thread-pool-size 200
 #
 
-CLASSPATH=lighty-toaster-multiple-devices-17.3.0.jar
+CLASSPATH=lighty-toaster-multiple-devices-17.4.0-SNAPSHOT.jar
 
 ARGUMENT_LIST=(
     "device-count"

--- a/examples/devices/pom.xml
+++ b/examples/devices/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>devices-aggregator</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -18,5 +18,5 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-data-center-model</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
 </project>

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-network-topology-device-model</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -18,6 +18,6 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-example-notifications-model</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
 
 </project>

--- a/examples/models/pom.xml
+++ b/examples/models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-bom</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,42 +26,42 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-network-topology-device-model</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-data-center-model</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device</groupId>
                 <artifactId>lighty-netconf-device</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-actions-device</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-device</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-network-topology-device</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>lighty-toaster-multiple-devices</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples.models</groupId>
                 <artifactId>lighty-example-notifications-model</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-parent</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>examples-bom</artifactId>
-                <version>17.3.0</version>
+                <version>17.4.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/parents/pom.xml
+++ b/examples/parents/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.netconf.device.examples.parents</groupId>
     <artifactId>parents-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
 
     <modules>
         <module>examples-parent</module>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
     <groupId>io.lighty.netconf.device.examples</groupId>
     <artifactId>examples-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
 
     <modules>
         <module>parents</module>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>lighty-netconf-device</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.netconf.device</groupId>
     <artifactId>netconf-device-aggregator</artifactId>
-    <version>17.3.0</version>
+    <version>17.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Start next development iteration towards to compatibility
release with Lighty.io 17.4.0.

JIRA:LIGHTY-219