### PR TITLE
Fixed warning in pom.xml file

### DIFF
--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -15,6 +15,7 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
         <version>17.2.0</version>
+        <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device</groupId>


### PR DESCRIPTION
This commit resolves a warning in the pom.xml file located at /lighty-netconf-simulator/lighty-netconf-device/pom.xml. The warning, which was pointing at the incorrect parent.relativePath, has been fixed by adding the <relativePath/> tag. This change ensures that the project structure is aligned correctly,
replacing io.lighty.netconf.device:netconf-device-aggregator with the expected io.lighty.core:lighty-parent.

JIRA: LIGHTY-226
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit c18686395330914b3ef956c437a81c64727aabbb)