### PR TITLE
Fix all relative paths to lighty core

### DIFF
--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -13,6 +13,7 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
         <version>18.1.0</version>
+        <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -13,6 +13,7 @@
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
         <version>18.1.0</version>
+        <relativePath/>
     </parent>
 
     <groupId>io.lighty.netconf.device.examples.models</groupId>


### PR DESCRIPTION
Fix all relative paths for parents which are located in lighty.io core.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 38060861b1c314a260e509418816296ebc17020b)