### PR TITLE
Bump Lighty.io to 18.2.0

### DIFF
--- a/examples/models/lighty-example-data-center-model/pom.xml
+++ b/examples/models/lighty-example-data-center-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>18.1.0</version>
+        <version>18.2.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/models/lighty-example-network-topology-device-model/pom.xml
+++ b/examples/models/lighty-example-network-topology-device-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>18.1.0</version>
+        <version>18.2.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/models/lighty-example-notifications-model/pom.xml
+++ b/examples/models/lighty-example-notifications-model/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>18.1.0</version>
+        <version>18.2.0</version>
         <relativePath/>
     </parent>
 

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>18.1.0</version>
+        <version>18.2.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>18.1.0</version>
+        <version>18.2.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Use Lighty.io version 18.2.0 for simulator release 18.2.0.

JIRA:LIGHTY-244