### PR TITLE
Bump org.xmlunit to 2.9.1

### DIFF
--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -55,18 +55,5 @@
             <artifactId>xmlunit-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-matchers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-assertj</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
-
 </project>
-

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -9,9 +9,9 @@ package io.lighty.netconf.device.topology;
 
 import static io.lighty.netconf.device.topology.TestUtils.xmlFileToInputStream;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -44,6 +44,10 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 public class DeviceTest {
 
@@ -236,9 +240,14 @@ public class DeviceTest {
 
     private void assertResponseIsIdentical(final NetconfMessage response, final InputStream comparedResponse) {
         assertNotNull(response);
-        assertThat(response.getDocument())
-                .and(comparedResponse)
-                .ignoreWhitespace()
-                .areIdentical();
+        final var actual = Input.fromString(response.toString()).build();
+        final var expected = Input.fromStream(comparedResponse).build();
+
+        final var diff = DiffBuilder.compare(actual).withTest(expected)
+            .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+            .checkForIdentical()
+            .ignoreWhitespace()
+            .build();
+        assertFalse(diff.hasDifferences(), "XML identical " + diff);
     }
 }

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -77,17 +77,7 @@
             <dependency>
                 <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-core</artifactId>
-                <version>2.7.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-matchers</artifactId>
-                <version>2.7.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-assertj</artifactId>
-                <version>2.7.0</version>
+                <version>2.9.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Remove xmlunit-matchers and xmlunit-assertj and reimplement the test with xmlunit-core version 2.9.1.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 2f54bf54129671c4a14f74339797f57991ed708b)