### PR TITLE
Bump org.xmlunit to 2.9.1

### DIFF
--- a/examples/devices/lighty-network-topology-device/pom.xml
+++ b/examples/devices/lighty-network-topology-device/pom.xml
@@ -55,18 +55,5 @@
             <artifactId>xmlunit-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-matchers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-assertj</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
-
 </project>
-

--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -77,17 +77,7 @@
             <dependency>
                 <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-core</artifactId>
-                <version>2.7.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-matchers</artifactId>
-                <version>2.7.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-assertj</artifactId>
-                <version>2.7.0</version>
+                <version>2.9.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Remove xmlunit-matchers and xmlunit-assertj and reimplement the test with xmlunit-core version 2.9.1.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 2f54bf54129671c4a14f74339797f57991ed708b)