### PR TITLE
Suppress warnings for ActionServiceDeviceProcessor

### DIFF
--- a/examples/devices/lighty-actions-device/pom.xml
+++ b/examples/devices/lighty-actions-device/pom.xml
@@ -35,17 +35,21 @@
             <groupId>io.lighty.netconf.device</groupId>
             <artifactId>lighty-netconf-device</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
 
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ActionServiceDeviceProcessor.java
+++ b/examples/devices/lighty-actions-device/src/main/java/io/lighty/netconf/device/action/processors/ActionServiceDeviceProcessor.java
@@ -10,6 +10,7 @@ package io.lighty.netconf.device.action.processors;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lighty.codecs.util.exception.SerializationException;
 import io.lighty.netconf.device.NetconfDeviceServices;
 import io.lighty.netconf.device.action.actions.ResetAction;
@@ -48,6 +49,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+@SuppressFBWarnings("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
 public class ActionServiceDeviceProcessor extends BaseRequestProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(ActionServiceDeviceProcessor.class);


### PR DESCRIPTION
Suppress WF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR FindBugs warnings in ActionServiceDeviceProcessor class.

To properly handle this class would be refactored in the future.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 507f20be97b8a9314a449e94a9531eacfa142b88)