### PR TITLE
Remove NioEventLoopGroup usage

### DIFF
--- a/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
+++ b/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
@@ -11,8 +11,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -28,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendaylight.netconf.api.messages.NetconfMessage;
 import org.opendaylight.netconf.api.xml.XmlUtil;
-import org.opendaylight.netconf.client.NetconfClientFactory;
 import org.opendaylight.netconf.client.NetconfClientFactoryImpl;
 import org.opendaylight.netconf.client.NetconfClientSession;
 import org.opendaylight.netconf.client.NetconfClientSessionListener;
@@ -66,21 +63,18 @@ public class ActionDeviceTest {
     public static final String RESET_TAG = "reset-finished-at";
 
     private static Main deviceSimulator;
-    private static NioEventLoopGroup nettyGroup;
     private static NetconfClientFactoryImpl dispatcher;
 
     @BeforeAll
     public static void setUpClass() {
         deviceSimulator = new Main();
         deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false);
-        nettyGroup = new NioEventLoopGroup(1, new DefaultThreadFactory(NetconfClientFactory.class));
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
 
     @AfterAll
     public static void cleanUpClass() throws InterruptedException {
         deviceSimulator.shutdown();
-        nettyGroup.shutdownGracefully().sync();
     }
 
     private static NetconfClientConfiguration createSHHConfig(final NetconfClientSessionListener sessionListener) {

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -14,8 +14,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -74,7 +72,6 @@ public class DeviceTest {
     private static final String DELETE_TOPOLOGY_CONFIG_REQUEST_XML = "delete_topology_config_request.xml";
     private static final String GET_SCHEMAS_REQUEST_XML = "get_schemas_request.xml";
     private static Main deviceSimulator;
-    private static NioEventLoopGroup nettyGroup;
     private static NetconfClientFactory dispatcher;
 
 
@@ -83,14 +80,12 @@ public class DeviceTest {
         deviceSimulator = new Main();
         deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false);
 
-        nettyGroup = new NioEventLoopGroup(1, new DefaultThreadFactory(NetconfClientFactory.class));
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
 
     @AfterAll
     public static void cleanUpClass() throws InterruptedException {
         deviceSimulator.shutdown();
-        nettyGroup.shutdownGracefully().sync();
     }
 
     private static NetconfClientConfiguration createSHHConfig(final NetconfClientSessionListener sessionListener) {

--- a/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
+++ b/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
@@ -11,8 +11,6 @@ import static org.testng.Assert.assertTrue;
 
 import io.lighty.netconf.device.notification.Main;
 import io.lighty.netconf.device.utils.TimeoutUtil;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -65,13 +63,11 @@ public class NotificationTest {
     private static final String EXPECTED_NOTIFICATION_PAYLOAD = "Test Notification";
     private static final String GET_SCHEMAS_REQUEST_XML = "get_schemas_request.xml";
     private static Main deviceSimulator;
-    private static NioEventLoopGroup nettyGroup;
     private static NetconfClientFactory dispatcher;
 
     @BeforeAll
     public static void setupClass() {
         deviceSimulator = new Main();
-        nettyGroup = new NioEventLoopGroup(1, new DefaultThreadFactory(NetconfClientFactory.class));
         deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false);
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
@@ -79,7 +75,6 @@ public class NotificationTest {
     @AfterAll
     public static void cleanUpClass() throws InterruptedException {
         deviceSimulator.shutdown();
-        nettyGroup.shutdownGracefully().sync();
     }
 
     private static NetconfClientConfiguration createSHHConfig(final NetconfClientSessionListener sessionListener) {

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -12,8 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendaylight.netconf.api.messages.NetconfMessage;
 import org.opendaylight.netconf.api.xml.XmlUtil;
-import org.opendaylight.netconf.client.NetconfClientFactory;
 import org.opendaylight.netconf.client.NetconfClientFactoryImpl;
 import org.opendaylight.netconf.client.NetconfClientSession;
 import org.opendaylight.netconf.client.NetconfClientSessionListener;
@@ -68,21 +65,18 @@ public class ToasterDeviceTest {
     public static final String GET_SCHEMAS_REQUEST_XML = "get_schemas_request.xml";
 
     private static Main deviceSimulator;
-    private static NioEventLoopGroup nettyGroup;
     private static NetconfClientFactoryImpl dispatcher;
 
     @BeforeAll
     public static void setUpClass() {
         deviceSimulator = new Main();
         deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false);
-        nettyGroup = new NioEventLoopGroup(1, new DefaultThreadFactory(NetconfClientFactory.class));
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
 
     @AfterAll
     public static void cleanUpClass() throws InterruptedException {
         deviceSimulator.shutdown();
-        nettyGroup.shutdownGracefully().sync();
     }
 
     private static NetconfClientConfiguration createSHHConfig(final NetconfClientSessionListener sessionListener) {

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
@@ -10,8 +10,6 @@ package io.lighty.netconf.device.toaster;
 import static org.testng.Assert.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -72,7 +70,6 @@ public class DeviceTest {
     private static final List<SimpleNetconfClientSessionListener> SESSION_LISTENERS = new ArrayList<>();
     private static final List<NetconfClientSession> NETCONF_CLIENT_SESSIONS = new ArrayList<>();
     private static Main deviceSimulator;
-    private static NioEventLoopGroup nettyGroup;
 
     @BeforeAll
     public static void setUpClass() throws InterruptedException, ExecutionException,
@@ -82,7 +79,6 @@ public class DeviceTest {
                         String.valueOf(DEVICE_STARTING_PORT), "--thread-pool-size",
                         String.valueOf(THREAD_POOL_SIZE), "--device-count", String.valueOf(DEVICE_COUNT)},
                 true, false);
-        nettyGroup = new NioEventLoopGroup(THREAD_POOL_SIZE, new DefaultThreadFactory(NetconfClientFactory.class));
         NetconfClientFactory dispatcher =
                 new NetconfClientFactoryImpl(new DefaultNetconfTimer());
         for (int port = DEVICE_STARTING_PORT; port < DEVICE_STARTING_PORT + DEVICE_COUNT; port++) {
@@ -98,7 +94,6 @@ public class DeviceTest {
     public static void cleanUpClass() throws InterruptedException {
         NETCONF_CLIENT_SESSIONS.forEach(AbstractNetconfSession::close);
         deviceSimulator.shutdown();
-        nettyGroup.shutdownGracefully().sync();
     }
 
     @Test


### PR DESCRIPTION
After adapting to NETCONF's new transport introduced in NETCONF-1108 we no more need to create our won NioEventLoopGroup.