### PR TITLE
Add persistence to lighty-network-topology-device

### DIFF
--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -630,3 +630,24 @@ It contains information about topology created, and the time event occurred.
 
 This notification is sent, when topology was deleted from device.
 It contains information about topology deleted, and the time event occurred.
+
+## Persistence
+This NETCONF device simulator supports persistence, allowing data to be stored and reloaded between sessions.
+Persistence can be manually enabled or disabled in the application's initial arguments.
+### Configuration Options
+* **Directory for Persistence Files:** 
+Specify the directory for storing and loading persisted data using the -Dconfig.dir=/path/to/directory JVM argument. <br>
+Example: `-Dconfig.dir=/home/user/config`
+
+* **Required Datastore Files:**
+The directory **must** contain the following files:<br>
+`initial-network-topo-config-datastore.xml` <br>
+`initial-network-topo-operational-datastore.xml` <br>
+ Note: _If persistance is disabled, the files and directory are not required to be specified._ <br>
+
+* **Default Behavior:**
+If no directory is specified and persistence is enabled, the application will use the files located in: <br>
+`examples/devices/lighty-network-topology-device/src/main/resources` <br>
+
+Example Startup Command:
+`java -Dconfig.dir=/home/user/IdeaProjects/lighty-netconf-simulator/examples/devices/lighty-network-topology-device/src/main/resources -jar lighty-network-topology-device-22.0.0-SNAPSHOT.jar`

--- a/examples/devices/lighty-network-topology-device/src/main/resources/initial-network-topo-operational-datastore.xml
+++ b/examples/devices/lighty-network-topology-device/src/main/resources/initial-network-topo-operational-datastore.xml
@@ -1,8 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-    <network-topology xmlns="urn:TBD:params:xml:ns:yang:network-topology">
-        <topology>
-            <topology-id>default-topology</topology-id>
-        </topology>
-    </network-topology>
-</data>

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -78,13 +78,13 @@ public class DeviceTest {
     @BeforeAll
     public static void setUpClass() {
         deviceSimulator = new Main();
-        deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false);
+        deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false, false);
 
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
 
     @AfterAll
-    public static void cleanUpClass() throws InterruptedException {
+    public static void cleanUpClass() {
         deviceSimulator.shutdown();
     }
 

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -70,7 +70,7 @@ public class ToasterDeviceTest {
     @BeforeAll
     public static void setUpClass() {
         deviceSimulator = new Main();
-        deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false);
+        deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false, false);
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
 

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
@@ -78,7 +78,7 @@ public class DeviceTest {
         deviceSimulator.start(new String[]{"--starting-port",
                         String.valueOf(DEVICE_STARTING_PORT), "--thread-pool-size",
                         String.valueOf(THREAD_POOL_SIZE), "--device-count", String.valueOf(DEVICE_COUNT)},
-                true, false);
+                true, false, false);
         NetconfClientFactory dispatcher =
                 new NetconfClientFactoryImpl(new DefaultNetconfTimer());
         for (int port = DEVICE_STARTING_PORT; port < DEVICE_STARTING_PORT + DEVICE_COUNT; port++) {
@@ -91,7 +91,7 @@ public class DeviceTest {
     }
 
     @AfterAll
-    public static void cleanUpClass() throws InterruptedException {
+    public static void cleanUpClass() {
         NETCONF_CLIENT_SESSIONS.forEach(AbstractNetconfSession::close);
         deviceSimulator.shutdown();
     }

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -50,6 +50,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/NetconfDeviceBuilder.java
@@ -16,7 +16,7 @@ import io.lighty.netconf.device.requests.RequestProcessor;
 import io.lighty.netconf.device.requests.notification.CreateSubscriptionRequestProcessor;
 import io.lighty.netconf.device.requests.notification.NotificationPublishServiceImpl;
 import io.lighty.netconf.device.utils.ModelUtils;
-import java.io.InputStream;
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,8 +33,8 @@ public class NetconfDeviceBuilder {
 
     private Set<YangModuleInfo> moduleInfos;
     private ConfigurationBuilder configurationBuilder;
-    private InputStream initialOperationalData;
-    private InputStream initialConfigurationData;
+    private File operationalData;
+    private File configurationData;
     private Map<QName, RequestProcessor> requestProcessors;
     private Set<String> allCapabilities;
     private NotificationPublishServiceImpl creator;
@@ -66,13 +66,13 @@ public class NetconfDeviceBuilder {
         return this;
     }
 
-    public NetconfDeviceBuilder setInitialOperationalData(InputStream initialOperationalData) {
-        this.initialOperationalData = initialOperationalData;
+    public NetconfDeviceBuilder setOperationalDatastore(File operationalDataFile) {
+        this.operationalData = operationalDataFile;
         return this;
     }
 
-    public NetconfDeviceBuilder setInitialConfigurationData(InputStream initialConfigurationData) {
-        this.initialConfigurationData = initialConfigurationData;
+    public NetconfDeviceBuilder setConfigDatastore(File configurationDataFile) {
+        this.configurationData = configurationDataFile;
         return this;
     }
 
@@ -185,7 +185,7 @@ public class NetconfDeviceBuilder {
         this.configurationBuilder.setGetDefaultYangResources(Collections.emptySet());
         this.configurationBuilder.setModels(moduleInfos);
         return new NetconfDeviceImpl(moduleInfos, configurationBuilder.build(),
-            initialOperationalData, initialConfigurationData, requestProcessors, creator,
+            operationalData, configurationData, requestProcessors, creator,
             netconfMonitoringEnabled);
     }
 

--- a/lighty-netconf-device/src/test/java/io/lighty/netconf/device/NetconfDeviceImplTest.java
+++ b/lighty-netconf-device/src/test/java/io/lighty/netconf/device/NetconfDeviceImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 PANTHEON.tech, s.r.o. and others. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.netconf.device;
+
+import io.lighty.codecs.util.exception.DeserializationException;
+import io.lighty.core.common.models.ModuleId;
+import io.lighty.netconf.device.utils.ModelUtils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opendaylight.mdsal.binding.api.WriteTransaction;
+import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NetworkTopology;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TopologyId;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.Topology;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.TopologyBuilder;
+import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.NodeBuilder;
+import org.opendaylight.yangtools.binding.meta.YangModuleInfo;
+import org.opendaylight.yangtools.yang.binding.InstanceIdentifier;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNodes;
+import org.testng.Assert;
+
+public class NetconfDeviceImplTest {
+
+    private static final long REQUEST_TIMEOUT_MILLIS = 5_000;
+    private static NetconfDeviceImpl netconfDevice;
+
+    @BeforeAll
+    public static void setUp() {
+        //set up a simple device
+        final Set<YangModuleInfo> modules = ModelUtils.getModelsFromClasspath(
+            ModuleId.from("urn:tech.pantheon.netconfdevice.network.topology.rpcs",
+                "network-topology-rpcs",
+                "2023-09-27"),
+            ModuleId.from("urn:opendaylight:netconf-node-topology",
+                "netconf-node-topology",
+                "2023-11-21"),
+            ModuleId.from("urn:TBD:params:xml:ns:yang:network-topology",
+                "network-topology",
+                "2013-10-21"));
+
+        netconfDevice = (NetconfDeviceImpl) new NetconfDeviceBuilder()
+            .setCredentials("admin", "admin")
+            .setBindingPort(17830)
+            .withModels(modules)
+            .build();
+        netconfDevice.start();
+    }
+
+    @AfterAll
+    public static void cleanUp() throws Exception {
+        netconfDevice.close();
+    }
+
+    @Test
+    public void testInitDatastore() throws ExecutionException, InterruptedException, TimeoutException {
+        //get the file as stream
+        final File file = new File(
+            NetconfDeviceImplTest.class.getResource("/initial-network-topo-config-datastore.xml").getFile());
+        //use the stream to init datastore
+        netconfDevice.initDatastore(LogicalDatastoreType.CONFIGURATION,
+            file);
+        //create identifier
+        final Topology topology = new TopologyBuilder().setTopologyId(new TopologyId("default-topology")).build();
+        final InstanceIdentifier<Topology> tii =
+            InstanceIdentifier.builder(NetworkTopology.class)
+                .child(Topology.class, topology.key())
+                .build();
+        //read the datastore using the identifier from the simulator
+        final Topology response = netconfDevice.getNetconfDeviceServices().getDataBroker().newReadOnlyTransaction()
+            .read(LogicalDatastoreType.CONFIGURATION, tii).get(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).get();
+        //check if the simulator contains the initial datastore
+        Assert.assertEquals(response.getNode().values().size(), 2);
+        Assert.assertTrue(response.getNode().values().contains(
+            new NodeBuilder().setNodeId(new NodeId("new-netconf-device")).build()));
+        Assert.assertTrue(response.getNode().values().contains(
+            new NodeBuilder().setNodeId(new NodeId("new-netconf-device-1")).build()));
+    }
+
+    @Test
+    public void testSaveDatastore() throws ExecutionException, InterruptedException,
+        TimeoutException, DeserializationException {
+        //create identifier
+        final Topology topology = new TopologyBuilder().setTopologyId(new TopologyId("default-topology")).build();
+        final InstanceIdentifier<Topology> tii =
+            InstanceIdentifier.builder(NetworkTopology.class)
+                .child(Topology.class, topology.key())
+                .build();
+        //write a new topology to device using the identifier
+        final WriteTransaction writeTransaction =
+            netconfDevice.getNetconfDeviceServices().getDataBroker().newWriteOnlyTransaction();
+        writeTransaction.put(LogicalDatastoreType.CONFIGURATION, tii,
+            new TopologyBuilder().setTopologyId(new TopologyId("default-topology")).build());
+        writeTransaction.commit().get(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        //save the datastore to temporary file called saved-datastore.xml
+        netconfDevice.saveDatastore(
+            new File("./src/test/resources/saved-datastore.xml"), LogicalDatastoreType.CONFIGURATION);
+        //verify that the file exists and contains the topology
+        final File file = new File("./src/test/resources/saved-datastore.xml");
+        Assert.assertTrue(file.exists());
+        try (InputStream stream = new FileInputStream(file)) {
+            Assert.assertNotNull(stream);
+            final Reader reader = new InputStreamReader(stream, Charset.defaultCharset());
+            final NormalizedNode initialDataBI = netconfDevice.getNetconfDeviceServices().getXmlNodeConverter()
+                .deserialize(netconfDevice.getNetconfDeviceServices().getRootInference(), reader);
+            final String dataTreeString = NormalizedNodes.toStringTree(initialDataBI);
+            Assert.assertTrue(dataTreeString.contains("default-topology"));
+            Assert.assertTrue(dataTreeString.contains("default-topology"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            //delete the temporary file
+            file.delete();
+        }
+    }
+}

--- a/lighty-netconf-device/src/test/resources/initial-network-topo-config-datastore.xml
+++ b/lighty-netconf-device/src/test/resources/initial-network-topo-config-datastore.xml
@@ -1,0 +1,13 @@
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <network-topology xmlns="urn:TBD:params:xml:ns:yang:network-topology">
+        <topology>
+            <topology-id>default-topology</topology-id>
+            <node>
+                <node-id>new-netconf-device-1</node-id>
+            </node>
+            <node>
+                <node-id>new-netconf-device</node-id>
+            </node>
+        </topology>
+    </network-topology>
+</data>


### PR DESCRIPTION
Add persistence to this module, the datastore is saved to a file which can be later used
to start the device again keeping the datastore.