### PR TITLE
Rework all applications to use ArgumentParser

### DIFF
--- a/examples/devices/lighty-network-topology-device/README.md
+++ b/examples/devices/lighty-network-topology-device/README.md
@@ -634,20 +634,20 @@ It contains information about topology deleted, and the time event occurred.
 ## Persistence
 This NETCONF device simulator supports persistence, allowing data to be stored and reloaded between sessions.
 Persistence can be manually enabled or disabled in the application's initial arguments.
+
 ### Configuration Options
 * **Directory for Persistence Files:** 
-Specify the directory for storing and loading persisted data using the -Dconfig.dir=/path/to/directory JVM argument. <br>
-Example: `-Dconfig.dir=/home/user/config`
+Specify the directory for storing and loading persisted data using the -i JVM argument. <br>
+Example: `-i /home/user/config`
 
 * **Required Datastore Files:**
 The directory **must** contain the following files:<br>
 `initial-network-topo-config-datastore.xml` <br>
 `initial-network-topo-operational-datastore.xml` <br>
- Note: _If persistance is disabled, the files and directory are not required to be specified._ <br>
+ Note: _Using the -i and -o path for the same directory will result in persistence (data will be rewritten when application closes)._ <br>
 
 * **Default Behavior:**
-If no directory is specified and persistence is enabled, the application will use the files located in: <br>
-`examples/devices/lighty-network-topology-device/src/main/resources` <br>
+When -i argument is not set, persistence is disabled by default: <br>
 
 Example Startup Command:
-`java -Dconfig.dir=/home/user/IdeaProjects/lighty-netconf-simulator/examples/devices/lighty-network-topology-device/src/main/resources -jar lighty-network-topology-device-22.0.0-SNAPSHOT.jar`
+`java -jar lighty-network-topology-device-22.0.0-SNAPSHOT.jar -i path/to/persistence/directory -o path/to/persistence/directory`

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -78,7 +78,7 @@ public class DeviceTest {
     @BeforeAll
     public static void setUpClass() {
         deviceSimulator = new Main();
-        deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false, false);
+        deviceSimulator.start(new String[]{"-p" + DEVICE_SIMULATOR_PORT}, false);
 
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }

--- a/examples/devices/lighty-toaster-device/README.md
+++ b/examples/devices/lighty-toaster-device/README.md
@@ -314,3 +314,24 @@ toast type: pink-bread)
 </rpc-reply>
 ]]>]]>
 ```
+
+## Persistence
+This NETCONF device simulator supports persistence, allowing data to be stored and reloaded between sessions.
+Persistence can be manually enabled or disabled in the application's initial arguments.
+
+### Configuration Options
+* **Directory for Persistence Files:**
+  Specify the directory for storing and loading persisted data using the -i JVM argument. <br>
+  Example: `-i /home/user/config`
+
+* **Required Datastore Files:**
+  The directory **must** contain the following files:<br>
+  `initial-network-topo-config-datastore.xml` <br>
+  `initial-network-topo-operational-datastore.xml` <br>
+  Note: _Using the -i and -o path for the same directory will result in persistence (data will be rewritten when application closes)._ <br>
+
+* **Default Behavior:**
+  When -i argument is not set, persistence is disabled by default: <br>
+
+Example Startup Command:
+`java -jar lighty-toaster-device-22.0.0-SNAPSHOT.jar -i path/to/persistence/directory -o path/to/persistence/directory`

--- a/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/Main.java
+++ b/examples/devices/lighty-toaster-device/src/main/java/io/lighty/netconf/device/toaster/Main.java
@@ -15,9 +15,12 @@ import io.lighty.netconf.device.toaster.processors.ToasterServiceCancelToastProc
 import io.lighty.netconf.device.toaster.processors.ToasterServiceMakeToastProcessor;
 import io.lighty.netconf.device.toaster.processors.ToasterServiceRestockToasterProcessor;
 import io.lighty.netconf.device.toaster.rpcs.ToasterServiceImpl;
+import io.lighty.netconf.device.utils.ArgumentParser;
 import io.lighty.netconf.device.utils.ModelUtils;
 import java.io.File;
+import java.util.List;
 import java.util.Set;
+import net.sourceforge.argparse4j.inf.Namespace;
 import org.opendaylight.yangtools.binding.meta.YangModuleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,17 +32,22 @@ public class Main {
 
     public static void main(String[] args) {
         Main app = new Main();
-        app.start(args, true, true, true);
+        app.start(args, true);
     }
 
     public void start(String[] args) {
-        start(args, false, true, true);
+        start(args, false);
     }
 
     @SuppressFBWarnings({"SLF4J_SIGN_ONLY_FORMAT", "OBL_UNSATISFIED_OBLIGATION"})
-    public void start(String[] args, boolean registerShutdownHook, final boolean initDatastore,
-        final boolean saveDatastore) {
-        int port = getPortFromArgs(args);
+    public void start(String[] args, boolean registerShutdownHook) {
+        final ArgumentParser argumentParser = new ArgumentParser();
+        final Namespace parseArguments = argumentParser.parseArguments(args);
+
+        //parameters are stored as string list
+        final List<?> portList = parseArguments.get("port");
+        final int port = Integer.parseInt(String.valueOf(portList.getFirst()));
+
         LOG.info("Lighty-Toaster device started at port {}", port);
         LOG.info("___________             __        ________              .__");
         LOG.info("\\__    ___/___  _______/  |_______\\______ \\   _______  _|__| ____  ____");
@@ -81,14 +89,14 @@ public class Main {
         File configFile = null;
         final String configDir = System.getProperty("config.dir",
             "./examples/devices/lighty-toaster-device/src/main/resources");
-        if (initDatastore) {
+        if (argumentParser.isInitDatastore()) {
             LOG.info("Using initial datastore from: {}", configDir);
             operationalFile = new File(
                 configDir, "initial-toaster-operational-datastore.xml");
             configFile = new File(
                 configDir, "initial-toaster-config-datastore.xml");
         }
-        if (saveDatastore) {
+        if (argumentParser.isSaveDatastore()) {
             operationalFile = new File(configDir, "initial-toaster-operational-datastore.xml");
             configFile = new File(configDir, "initial-toaster-config-datastore.xml");
         }
@@ -144,14 +152,4 @@ public class Main {
             }
         }
     }
-
-    @SuppressWarnings("checkstyle:IllegalCatch")
-    private static int getPortFromArgs(String[] args) {
-        try {
-            return Integer.parseInt(args[0]);
-        } catch (Exception e) {
-            return 17830;
-        }
-    }
-
 }

--- a/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
+++ b/examples/devices/lighty-toaster-device/src/test/java/io/lighty/netconf/device/toaster/ToasterDeviceTest.java
@@ -70,7 +70,7 @@ public class ToasterDeviceTest {
     @BeforeAll
     public static void setUpClass() {
         deviceSimulator = new Main();
-        deviceSimulator.start(new String[]{DEVICE_SIMULATOR_PORT + ""}, false, false, false);
+        deviceSimulator.start(new String[]{"-p" + DEVICE_SIMULATOR_PORT}, false);
         dispatcher = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
     }
 

--- a/examples/devices/lighty-toaster-multiple-devices/README.md
+++ b/examples/devices/lighty-toaster-multiple-devices/README.md
@@ -178,3 +178,24 @@ toast type: pink-bread)
 </rpc-reply>
 ]]>]]>
 ```
+
+## Persistence
+This NETCONF device simulator supports persistence, allowing data to be stored and reloaded between sessions.
+Persistence can be manually enabled or disabled in the application's initial arguments.
+
+### Configuration Options
+* **Directory for Persistence Files:**
+  Specify the directory for storing and loading persisted data using the -i JVM argument. <br>
+  Example: `-i /home/user/config`
+
+* **Required Datastore Files:**
+  The directory **must** contain the following files:<br>
+  `initial-network-topo-config-datastore.xml` <br>
+  `initial-network-topo-operational-datastore.xml` <br>
+  Note: _Using the -i and -o path for the same directory will result in persistence (data will be rewritten when application closes)._ <br>
+
+* **Default Behavior:**
+  When -i argument is not set, persistence is disabled by default: <br>
+
+Example Startup Command:
+`java -jar lighty-toaster-multiple-devices-22.0.0-SNAPSHOT.jar -i path/to/persistence/directory -o path/to/persistence/directory`

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
@@ -75,10 +75,10 @@ public class DeviceTest {
     public static void setUpClass() throws InterruptedException, ExecutionException,
         TimeoutException, UnsupportedConfigurationException {
         deviceSimulator = new Main();
-        deviceSimulator.start(new String[]{"--starting-port",
-                        String.valueOf(DEVICE_STARTING_PORT), "--thread-pool-size",
-                        String.valueOf(THREAD_POOL_SIZE), "--device-count", String.valueOf(DEVICE_COUNT)},
-                true, false, false);
+        deviceSimulator.start(new String[]{ "--port", String.valueOf(DEVICE_STARTING_PORT),
+                                            "--thread-pool-size", String.valueOf(THREAD_POOL_SIZE),
+                                            "--devices-count", String.valueOf(DEVICE_COUNT)},
+                true);
         NetconfClientFactory dispatcher =
                 new NetconfClientFactoryImpl(new DefaultNetconfTimer());
         for (int port = DEVICE_STARTING_PORT; port < DEVICE_STARTING_PORT + DEVICE_COUNT; port++) {

--- a/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/ArgumentParser.java
+++ b/lighty-netconf-device/src/main/java/io/lighty/netconf/device/utils/ArgumentParser.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 PANTHEON.tech, s.r.o. and others. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.netconf.device.utils;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.util.List;
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+public class ArgumentParser {
+
+    public static final int DEFAULT_PORT = 17830;
+    public static final int DEFAULT_DEVICE_COUNT = 1;
+    public static final int DEFAULT_POOL_SIZE = 8;
+
+    private boolean initDatastore;
+    private boolean saveDatastore;
+
+    public Namespace parseArguments(final String[] args) {
+        final net.sourceforge.argparse4j.inf.ArgumentParser argumentParser =
+            ArgumentParsers.newFor("Lighty-netconf-simulator").build();
+
+        argumentParser.addArgument("-p", "--port")
+            .nargs(1)
+            .setDefault(List.of(DEFAULT_PORT))
+            .help("Sets port. If no value is set, default value is used (17830).");
+        argumentParser.addArgument("-i", "--init-datastore")
+            .nargs(1)
+            .help("Set path for the initial datastore folder which will be loaded. Folder must include two files "
+                + "named initial-network-topo-config-datastore.xml and initial-network-topo-operational-datastore.xml");
+        argumentParser.addArgument("-o", "--output-datastore")
+            .nargs(1)
+            .help("Set path where the output datastore which will be saved.");
+        argumentParser.addArgument("-d", "--devices-count")
+            .setDefault(List.of(DEFAULT_DEVICE_COUNT))
+            .help("Number of simulated netconf devices to spin."
+                + " This is the number of actual ports which will be used for the devices.")
+            .dest("devices-count");
+        argumentParser.addArgument("-t", "--thread-pool-size")
+            .setDefault(List.of(DEFAULT_POOL_SIZE))
+            .help("The number of threads to keep in the pool, "
+                + "when creating a device simulator, even if they are idle.")
+            .dest("thread-pool-size");
+
+        final Namespace namespace = argumentParser.parseArgsOrFail(args);
+        if (!(namespace.getString("init_datastore") == null)) {
+            initDatastore = true;
+            final String pathDoesNotExist = "Input datastore %s does not exist";
+            final String filename = namespace.getString("init_datastore").replaceAll("[\\[\\]]", "");
+            final File file = new File(filename);
+            Preconditions.checkArgument(file.exists(), String.format(pathDoesNotExist, filename));
+        } else {
+            initDatastore = false;
+        }
+        saveDatastore = !(namespace.get("output_datastore") == null);
+
+        return namespace;
+    }
+
+    public boolean isInitDatastore() {
+        return initDatastore;
+    }
+
+    public boolean isSaveDatastore() {
+        return saveDatastore;
+    }
+}


### PR DESCRIPTION
We already used argument parser in toaster-multiple-devices, and using different logic in other applications does not make sense. Standardize all aplications to use ArgumentParser to improve future development and add -help function and.

This change is also crutial in order to add persistence.

JIRA: LIGHTY-353