### PR TITLE
Use junit from lighty core

### DIFF
--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -65,16 +65,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>5.11.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.11.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-core</artifactId>
                 <version>2.10.3</version>


### PR DESCRIPTION
There is no need to set the version since we are getting it already from lighty core.

JIRA: LIGHTY-368

(cherry picked from commit 2e036659271381cf7dab257fe643da9296b6ebce)