### PR TITLE
Rework tests to use junit.jupiter

### DIFF
--- a/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
+++ b/examples/devices/lighty-actions-device/src/test/java/io/lighty/netconf/device/action/ActionDeviceTest.java
@@ -7,8 +7,8 @@
  */
 package io.lighty.netconf.device.action;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.io.File;
@@ -138,12 +138,12 @@ public class ActionDeviceTest {
             final NetconfMessage startActionResponse = sentRequesttoDevice(sessionListener, START_ACTION_REQUEST_XML);
             final String startResultTag = startActionResponse.getDocument().getDocumentElement().getElementsByTagName(
                     START_TAG).item(0).getTextContent();
-            assertEquals(startResultTag, START_ACTION_EXPECTED_VALUE);
+            assertEquals(START_ACTION_EXPECTED_VALUE, startResultTag);
 
             final NetconfMessage resetActionResponse = sentRequesttoDevice(sessionListener, RESET_ACTION_REQUEST_XML);
             final String resetResultTag = resetActionResponse.getDocument().getDocumentElement().getElementsByTagName(
                     RESET_TAG).item(0).getTextContent();
-            assertEquals(resetResultTag, RESET_ACTION_EXPECTED_VALUE);
+            assertEquals(RESET_ACTION_EXPECTED_VALUE, resetResultTag);
         }
     }
 

--- a/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
+++ b/examples/devices/lighty-network-topology-device/src/test/java/io/lighty/netconf/device/topology/DeviceTest.java
@@ -8,10 +8,10 @@
 package io.lighty.netconf.device.topology;
 
 import static io.lighty.netconf.device.topology.TestUtils.xmlFileToInputStream;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.io.IOException;
@@ -156,17 +156,17 @@ public class DeviceTest {
             final NetconfMessage getConfigDataResponse = sendRequestToDevice(GET_CONFIG_REQUEST_XML, sessionListener);
 
             final NodeList topologies = getConfigDataResponse.getDocument().getElementsByTagName("topology");
-            assertEquals(topologies.getLength(), 2);
+            assertEquals(2, topologies.getLength());
             if (getTopologyID(topologies.item(0)).equals("test-config-topology")) {
-                assertEquals(getTopologyID(topologies.item(0)), "test-config-topology");
-                assertEquals(getTopologyID(topologies.item(1)), "test-config-topology-merge");
+                assertEquals("test-config-topology", getTopologyID(topologies.item(0)));
+                assertEquals("test-config-topology-merge", getTopologyID(topologies.item(1)));
             } else {
-                assertEquals(getTopologyID(topologies.item(1)), "test-config-topology");
-                assertEquals(getTopologyID(topologies.item(0)), "test-config-topology-merge");
+                assertEquals("test-config-topology", getTopologyID(topologies.item(1)));
+                assertEquals("test-config-topology-merge", getTopologyID(topologies.item(0)));
             }
 
             final NodeList nodes = getConfigDataResponse.getDocument().getElementsByTagName("node");
-            assertEquals(nodes.getLength(), 1);
+            assertEquals(1, nodes.getLength());
 
             final NetconfMessage deleteTopologyResponse =
                     sendRequestToDevice(DELETE_TOPOLOGY_CONFIG_REQUEST_XML, sessionListener);
@@ -176,7 +176,7 @@ public class DeviceTest {
                     sendRequestToDevice(GET_CONFIG_REQUEST_XML, sessionListener);
             final NodeList topologiesAfterDelete =
                     getConfigDataResponseAfterDelete.getDocument().getElementsByTagName("topology");
-            assertEquals(topologiesAfterDelete.getLength(), 1);
+            assertEquals(1, topologiesAfterDelete.getLength());
         }
     }
 
@@ -229,8 +229,8 @@ public class DeviceTest {
                             .item(0).getFirstChild().getTextContent();
                     final String namespace = element.getElementsByTagName("namespace")
                             .item(0).getFirstChild().getTextContent();
-                    assertEquals(schemaFormat, "yang");
-                    assertEquals(location, "NETCONF");
+                    assertEquals("yang", schemaFormat);
+                    assertEquals("NETCONF", location);
                     assertNotNull(namespace);
                 }
             }

--- a/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
+++ b/examples/devices/lighty-notifications-device/src/test/java/io/lighty/devices/notification/tests/NotificationTest.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.devices.notification.tests;
 
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.netconf.device.notification.Main;
 import io.lighty.netconf.device.utils.TimeoutUtil;

--- a/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
+++ b/examples/devices/lighty-toaster-multiple-devices/src/test/java/io/lighty/netconf/device/toaster/DeviceTest.java
@@ -7,7 +7,7 @@
  */
 package io.lighty.netconf.device.toaster;
 
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.netconf.device.utils.TimeoutUtil;
 import java.io.File;
@@ -117,7 +117,7 @@ public class DeviceTest {
             final NetconfMessage schemaResponse = sendRequestToDevice(GET_SCHEMAS_REQUEST_XML,
                     listener);
             final NodeList schema = schemaResponse.getDocument().getDocumentElement().getElementsByTagName("schema");
-            Assertions.assertTrue(schema.getLength() > 0);
+            assertTrue(schema.getLength() > 0);
             boolean toasterSchemaContained = false;
             for (int i = 0; i < schema.getLength(); i++) {
                 if (schema.item(i).getNodeType() == Node.ELEMENT_NODE) {
@@ -131,7 +131,7 @@ public class DeviceTest {
                     }
                 }
             }
-            Assertions.assertTrue(toasterSchemaContained);
+            assertTrue(toasterSchemaContained);
         }
     }
 
@@ -141,7 +141,7 @@ public class DeviceTest {
         for (SimpleNetconfClientSessionListener listener : SESSION_LISTENERS) {
             final NetconfMessage makeToastResponse =
                     sendRequestToDevice(MAKE_TOAST_REQUEST_XML, listener);
-            Assertions.assertTrue(containsOkElement(makeToastResponse));
+            assertTrue(containsOkElement(makeToastResponse));
         }
     }
 

--- a/lighty-netconf-device/src/test/java/io/lighty/netconf/device/NetconfDeviceImplTest.java
+++ b/lighty-netconf-device/src/test/java/io/lighty/netconf/device/NetconfDeviceImplTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opendaylight.mdsal.binding.api.WriteTransaction;
@@ -36,7 +37,6 @@ import org.opendaylight.yangtools.binding.DataObjectIdentifier;
 import org.opendaylight.yangtools.binding.meta.YangModuleInfo;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNodes;
-import org.testng.Assert;
 
 public class NetconfDeviceImplTest {
 
@@ -88,10 +88,10 @@ public class NetconfDeviceImplTest {
         final Topology response = netconfDevice.getNetconfDeviceServices().getDataBroker().newReadOnlyTransaction()
             .read(LogicalDatastoreType.CONFIGURATION, tii).get(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).get();
         //check if the simulator contains the initial datastore
-        Assert.assertEquals(response.getNode().values().size(), 2);
-        Assert.assertTrue(response.getNode().values().contains(
+        Assertions.assertEquals(2, response.getNode().values().size());
+        Assertions.assertTrue(response.getNode().values().contains(
             new NodeBuilder().setNodeId(new NodeId("new-netconf-device")).build()));
-        Assert.assertTrue(response.getNode().values().contains(
+        Assertions.assertTrue(response.getNode().values().contains(
             new NodeBuilder().setNodeId(new NodeId("new-netconf-device-1")).build()));
     }
 
@@ -115,15 +115,14 @@ public class NetconfDeviceImplTest {
             new File("./src/test/resources/saved-datastore.xml"), LogicalDatastoreType.CONFIGURATION);
         //verify that the file exists and contains the topology
         final File file = new File("./src/test/resources/saved-datastore.xml");
-        Assert.assertTrue(file.exists());
+        Assertions.assertTrue(file.exists());
         try (InputStream stream = new FileInputStream(file)) {
-            Assert.assertNotNull(stream);
+            Assertions.assertNotNull(stream);
             final Reader reader = new InputStreamReader(stream, Charset.defaultCharset());
             final NormalizedNode initialDataBI = netconfDevice.getNetconfDeviceServices().getXmlNodeConverter()
                 .deserialize(netconfDevice.getNetconfDeviceServices().getRootInference(), reader);
             final String dataTreeString = NormalizedNodes.toStringTree(initialDataBI);
-            Assert.assertTrue(dataTreeString.contains("default-topology"));
-            Assert.assertTrue(dataTreeString.contains("default-topology"));
+            Assertions.assertTrue(dataTreeString.contains("default-topology"));
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {


### PR DESCRIPTION
Replace all testng and plain junit with junit.jupiter throughout the entire lighty.io project.

JIRA: LIGHTY-409