### PR TITLE
Do not override odlparent managed versions

### DIFF
--- a/examples/parents/examples-bom/pom.xml
+++ b/examples/parents/examples-bom/pom.xml
@@ -64,11 +64,6 @@
                 <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.xmlunit</groupId>
-                <artifactId>xmlunit-core</artifactId>
-                <version>2.11.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -28,18 +28,6 @@
         Parent pom for code artifacts using Lighty.io.
     </description>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.4</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -28,18 +28,6 @@
         Parent pom for code artifacts using Lighty.io.
     </description>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.5</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
We have some dependencies we usually bump according to odlparent. Assuming they are managed by ODL we do not need to manage them in lighty.io as well.
