### PR TITLE
Fix NoClassDefFoundError: dagger/internal/Provider

### DIFF
--- a/examples/parents/examples-parent/pom.xml
+++ b/examples/parents/examples-parent/pom.xml
@@ -30,6 +30,27 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- netconf-testtool's NetconfDeviceSimulator builds a DaggerDefaultYangParserComponent
+                 at runtime (via yangtools' dagger-yang-parser). odlparent pins com.google.dagger:dagger
+                 and its DI helper artifacts to "provided" scope, assuming an OSGi/Karaf container
+                 supplies the bundles. These example devices are standalone runnable fat-jars with no
+                 such container, so re-pin them to compile scope here so every example device's
+                 assembly bundles them. -->
+            <dependency>
+                <groupId>com.google.dagger</groupId>
+                <artifactId>dagger</artifactId>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.guicedee.services</groupId>
+                <artifactId>javax.inject</artifactId>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <scope>compile</scope>
+            </dependency>
             <dependency>
                 <groupId>io.lighty.netconf.device.examples</groupId>
                 <artifactId>examples-bom</artifactId>

--- a/lighty-netconf-device/pom.xml
+++ b/lighty-netconf-device/pom.xml
@@ -50,6 +50,27 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- netconf-testtool's NetconfDeviceSimulator builds a DaggerDefaultYangParserComponent at
+             runtime (via yangtools' dagger-yang-parser). odlparent pins com.google.dagger:dagger and
+             its DI helper artifacts to "provided" scope for OSGi/Karaf deployments where the bundles
+             are supplied by the container. Lighty's example devices run as standalone fat-jars with no
+             such container, so re-declare compile scope here to keep the jars on the runtime classpath
+             / assembled lib. -->
+        <dependency>
+            <groupId>com.google.dagger</groupId>
+            <artifactId>dagger</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.guicedee.services</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
Root cause: odlparent 14.3.1 (pulled in via lighty-core:24.0.0) pins three DI artifacts to provided scope in its dependency management - com.google.dagger:dagger, com.guicedee.services:javax.inject, and jakarta.inject:jakarta.inject-api - on the assumption an OSGi/Karaf container supplies them. But netconf-testtool's NetconfDeviceSimulator (used by lighty-netconf-device) now unconditionally builds a DaggerDefaultYangParserComponent at startup (new in yangtools 15.0.2), and the example devices here are standalone fat-jars with no such container, so those three jars get silently dropped from the assembled lib/ and Class-Path, and the process dies as soon as it tries to build a YANG parser.

JIRA: LIGHTY-453